### PR TITLE
fix: vite 环境下无法正常加载环境变量

### DIFF
--- a/packages/core/src/server/launch-editor.ts
+++ b/packages/core/src/server/launch-editor.ts
@@ -182,10 +182,17 @@ function getArgumentsForLineNumber(
   return [fileName];
 }
 
+/**
+ * webpack 会自动注入 `WEBPACK_DEV_SERVER` 
+ * 
+ * 需要根据是否为 vite 环境来获取不同的环境变量值
+ */
+const isVite = !process.env.WEBPACK_DEV_SERVER
+
 function guessEditor() {
   // Explicit config always wins
-  if (process.env.CODE_EDITOR) {
-    return shellQuote.parse(process.env.CODE_EDITOR);
+  if (isVite ? process.env.VITE_CODE_EDITOR : process.env.CODE_EDITOR) {
+    return shellQuote.parse(isVite ? process.env.VITE_CODE_EDITOR : process.env.CODE_EDITOR);
   }
 
   // We can find out which editor is currently running by:
@@ -263,7 +270,7 @@ function printInstructions(fileName: any, errorMessage: string | any[] | null) {
   }
   console.log(
     'To set up the editor integration, add something like ' +
-      chalk.cyan('CODE_EDITOR=atom') +
+      chalk.cyan(`${isVite ? 'VITE_CODE_EDITOR=atom' : 'CODE_EDITOR=atom'}`) +
       ' to the ' +
       chalk.green('.env.local') +
       ' file in your project folder ' +

--- a/packages/vite-plugin/README-EN.md
+++ b/packages/vite-plugin/README-EN.md
@@ -103,5 +103,5 @@ export default defineConfig({
   If your editor doesn't open automatically when you click on a page element, it could be because of system permissions or other issues that prevent the plugin from reading the programs currently running on your computer. Please add a file named `.env.local` to your project root directory, add the following content:
   ```perl
   # editor
-  CODE_EDITOR=code
+  VITE_CODE_EDITOR=code
   ```

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -103,5 +103,5 @@ export default defineConfig({
   如果你点击页面元素时无法自动打开代码编辑器，可能是因为系统权限或其他原因导致无法找到正在运行的代码编辑器。在项目根目录添加一个名为 `.env.local` 的文件并添加如下内容:
   ```perl
   # editor
-  CODE_EDITOR=code
+  VITE_CODE_EDITOR=code
   ```

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -24,7 +24,8 @@
   },
   "devDependencies": {
     "@types/node": "^16.0.1",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.3",
+    "vite": "^2.0.0"
   },
   "scripts": {
     "build": "tsc"

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -6,7 +6,7 @@ import {
   normalizePath,
 } from 'code-inspector-core';
 import path from 'path';
-
+import { loadEnv } from 'vite';
 const PluginName = 'vite-code-inspector-plugin';
 let rootPath = '';
 
@@ -28,8 +28,10 @@ export function ViteCodeInspectorPlugin(options?: Options) {
   return {
     name: PluginName,
     enforce: 'pre' as 'pre',
-    apply(_, { command }) {
-      return command === 'serve';
+    apply(_, { command, mode }) {
+      const isDev = command === 'serve'
+      if(isDev) process.env = {...process.env, ...loadEnv(mode, process.cwd())};
+      return isDev;
     },
     async transform(code, id) {
       if (!rootPath) {


### PR DESCRIPTION
在使用 vite 开发时，vite 默认只会注入以 `VITE_` 开头的环境变量。所以当基于 vite 开发时，需要配置 `VITE_CODE_EDITOR=atom` 来指定编辑器。

服务端在通过环境变量获取指定的编辑器时也应该根据不同的环境获取不同的值。

```ts
const isVite = !process.env.WEBPACK_DEV_SERVER

if(isVite ? process.env.VITE_CODE_EDITOR : process.env.CODE_EDITOR) {
  ...
}
```

还需要在扩展加载时，手动往 process.env 中注入环境变量。
```ts
import { loadEnv } from 'vite';
...
  apply(_, { command, mode }) {
      const isDev = command === 'serve'
      if(isDev) process.env = {...process.env, ...loadEnv(mode, process.cwd())};
      return isDev;
    },
...
```