### PR TITLE
解决Uncaught TypeError: i[0].indexOf is not a function问题

### DIFF
--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -233,7 +233,7 @@ export class MyElement extends LitElement {
     const originWarn = console.warn;
     const warning = `[Vue warn]: Extraneous non-props attributes (${PathName})`;
     console.warn = function (...args) {
-      if (args && args[0] && args[0].indexOf(warning) !== -1) {
+      if (typeof args?.[0] === 'string' && args[0].indexOf(warning) !== -1) {
         return;
       } else {
         originWarn(...args);


### PR DESCRIPTION
当args[0]不为字符串时，会报Uncaught TypeError: i[0].indexOf is not a function

example:
```js
console.warn('test string'); // √
console.warn(123); // × Uncaught TypeError: i[0].indexOf is not a function
console.warn({ a: 1}); // × Uncaught TypeError: i[0].indexOf is not a function
```