### PR TITLE
release: 0.1.8

### DIFF
--- a/packages/code-inspector-plugin/package.json
+++ b/packages/code-inspector-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-inspector-plugin",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "typings": "./types/index.d.ts",
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@types/node": "^16.0.1",
+    "dotenv": "^16.3.1",
     "typescript": "^4.9.3",
     "vite": "^4.1.0"
   }

--- a/packages/code-inspector-plugin/src/index.ts
+++ b/packages/code-inspector-plugin/src/index.ts
@@ -1,10 +1,21 @@
 import { ViteCodeInspectorPlugin } from 'vite-code-inspector-plugin';
 import { CodeOptions } from 'code-inspector-core';
 import chalk from 'chalk';
+import dotenv from 'dotenv';
+import path from 'path';
+import fs from 'fs';
 
 export interface CodeInspectorPluginOptions extends CodeOptions {
+  /**
+   * @zh 指定项目的打包器
+   * @en specify the bundler of the project
+   */
   bundler: 'vite' | 'webpack';
-  catch?: boolean;
+  /**
+   * @zh 设置为 true 时，仅当 .env.local 文件存在且其包含 CODE_INSPECTOR=true 时插件生效；默认值为 false
+   * @en When set the value to true, only if the .env.local file exists and it contains CODE_INSPECTOR=true, the plugin takes effect; The default value is false
+   */
+  needEnvInspector?: boolean;
 }
 
 export function CodeInspectorPlugin(options: CodeInspectorPluginOptions): any {
@@ -17,12 +28,32 @@ export function CodeInspectorPlugin(options: CodeInspectorPluginOptions): any {
     );
     return;
   }
+  // 判断是否只在本地启用
+  let close = false;
+  if (options.needEnvInspector) {
+    close = true;
+    let useCodeInspector = process.env.CODE_INSPECTOR;
+    if (useCodeInspector === 'true') {
+      close = false;
+    } else {
+      const envPath = path.resolve(process.cwd(), '.env.local');
+      if (fs.existsSync(envPath)) {
+        const envFile = fs.readFileSync(envPath, 'utf-8');
+        const envConfig = dotenv.parse(envFile || '');
+        const useCodeInspector = envConfig?.CODE_INSPECTOR;
+        if (useCodeInspector === 'true') {
+          close = false;
+        }
+      }
+    }
+  }
+
   if (options.bundler === 'webpack') {
     // 使用 webpack 插件
     const WebpackCodeInspectorPlugin = require('webpack-code-inspector-plugin');
-    return new WebpackCodeInspectorPlugin(options);
+    return new WebpackCodeInspectorPlugin({ ...options, close });
   } else {
     // 使用 vite 插件
-    return ViteCodeInspectorPlugin(options);
+    return ViteCodeInspectorPlugin({ ...options, close });
   }
 }

--- a/packages/code-inspector-plugin/types/index.d.ts
+++ b/packages/code-inspector-plugin/types/index.d.ts
@@ -1,6 +1,14 @@
 import { CodeOptions } from 'code-inspector-core';
 export interface CodeInspectorPluginOptions extends CodeOptions {
+    /**
+     * @zh 指定项目的打包器
+     * @en specify the bundler of the project
+     */
     bundler: 'vite' | 'webpack';
-    catch?: boolean;
+    /**
+     * @zh 设置为 true 时，仅当 .env.local 文件存在且其包含 CODE_INSPECTOR=true 时插件生效；默认值为 false
+     * @en When set the value to true, only if the .env.local file exists and it contains CODE_INSPECTOR=true, the plugin takes effect; The default value is false
+     */
+    needEnvInspector?: boolean;
 }
 export declare function CodeInspectorPlugin(options: CodeInspectorPluginOptions): any;

--- a/packages/code-inspector-plugin/vite.config.ts
+++ b/packages/code-inspector-plugin/vite.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
         'vite-code-inspector-plugin',
         'webpack-code-inspector-plugin',
         'chalk',
+        'fs',
+        'path',
       ],
     },
     target: ['node8', 'es2015'],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-inspector-core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "dist/index.js",
   "module": "./dist/index.mjs",
   "types": "types/index.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,8 +29,20 @@ const jsCode = fs.readFileSync(jsCodePath, 'utf-8');
 
 export type HotKey = 'ctrlKey' | 'altKey' | 'metaKey' | 'shiftKey';
 export type CodeOptions = {
+  /**
+   * @cn 触发 DOM 定位功能的组合键，ctrlKey/altKey/metaKey/shiftKey 中一个或多个组成的数组，默认值为 ['altKey', 'shiftKey]。即 Mac 系统默认是 Option + Shift；Window 默认是 Alt + Shift。
+   * @en The combination keys that triggers the DOM positioning function, it is an array of one or more from ctrlKey/altKey/metaKey/shiftKey, with default values of ['altKey', 'shiftKey']. The default for Mac systems is Option+Shift; and for Window is Alt+Shift.
+   */
   hotKeys?: HotKey[] | false;
+  /**
+   * @cn 是否在页面展示功能开关按钮
+   * @en Whether show the switch button of this function on the page
+   */
   showSwitch?: boolean;
+  /**
+   * @cn 打开功能开关的情况下，点击触发跳转编辑器时是否自动关闭开关
+   * @en When opening the function switch, whether automatically close the switch when triggering the jump editor function.
+   */
   autoToggle?: boolean;
 };
 

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -1,7 +1,19 @@
 export type HotKey = 'ctrlKey' | 'altKey' | 'metaKey' | 'shiftKey';
 export type CodeOptions = {
+    /**
+     * @cn 触发 DOM 定位功能的组合键，ctrlKey/altKey/metaKey/shiftKey 中一个或多个组成的数组，默认值为 ['altKey', 'shiftKey]。即 Mac 系统默认是 Option + Shift；Window 默认是 Alt + Shift。
+     * @en The combination keys that triggers the DOM positioning function, it is an array of one or more from ctrlKey/altKey/metaKey/shiftKey, with default values of ['altKey', 'shiftKey']. The default for Mac systems is Option+Shift; and for Window is Alt+Shift.
+     */
     hotKeys?: HotKey[] | false;
+    /**
+     * @cn 是否在页面展示功能开关按钮
+     * @en Whether show the switch button of this function on the page
+     */
     showSwitch?: boolean;
+    /**
+     * @cn 打开功能开关的情况下，点击触发跳转编辑器时是否自动关闭开关
+     * @en When opening the function switch, whether automatically close the switch when triggering the jump editor function.
+     */
     autoToggle?: boolean;
 };
 export declare function getInjectCode(port: number, options?: CodeOptions): string;

--- a/packages/demos/vite-vue3/vite.config.ts
+++ b/packages/demos/vite-vue3/vite.config.ts
@@ -5,5 +5,12 @@ import vueJsx from '@vitejs/plugin-vue-jsx';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue(), CodeInspectorPlugin({ bundler: 'vite' }), vueJsx()],
+  plugins: [
+    vue(),
+    CodeInspectorPlugin({
+      bundler: 'vite',
+      needEnvInspector: true,
+    }),
+    vueJsx(),
+  ],
 });

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-code-inspector-plugin",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "typings": "./types/index.d.ts",

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -2,17 +2,15 @@ import {
   enhanceCode,
   getInjectCode,
   startServer,
-  HotKey,
   normalizePath,
+  CodeOptions,
 } from 'code-inspector-core';
 import path from 'path';
 const PluginName = 'vite-code-inspector-plugin';
 let rootPath = '';
 
-interface Options {
-  hotKeys?: HotKey[] | false;
-  showSwitch?: boolean;
-  autoToggle?: boolean;
+interface Options extends CodeOptions {
+  close?: boolean;
 }
 
 const replaceHtml = (html, code) => {
@@ -28,6 +26,9 @@ export function ViteCodeInspectorPlugin(options?: Options) {
     name: PluginName,
     enforce: 'pre' as 'pre',
     apply(_, { command }) {
+      if (options?.close) {
+        return false;
+      }
       const isDev = command === 'serve';
       return isDev;
     },

--- a/packages/vite-plugin/types/index.d.ts
+++ b/packages/vite-plugin/types/index.d.ts
@@ -1,8 +1,6 @@
-import { HotKey } from 'code-inspector-core';
-interface Options {
-    hotKeys?: HotKey[] | false;
-    showSwitch?: boolean;
-    autoToggle?: boolean;
+import { CodeOptions } from 'code-inspector-core';
+interface Options extends CodeOptions {
+    close?: boolean;
 }
 export declare function ViteCodeInspectorPlugin(options?: Options): {
     name: string;

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-code-inspector-plugin",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.mjs",
   "typings": "./types/index.d.ts",

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -1,12 +1,18 @@
 import {
   getInjectCode,
   startServer,
-  HotKey,
   normalizePath,
+  CodeOptions,
 } from 'code-inspector-core';
 import path from 'path';
 
+let isFirstLoad = true;
+
 const applyLoader = (compiler: any, cb: () => void) => {
+  if (!isFirstLoad) {
+    return;
+  }
+  isFirstLoad = false;
   // 适配 webpack 各个版本
   const _compiler = compiler?.compiler || compiler;
   const module = _compiler?.options?.module;
@@ -57,11 +63,10 @@ const injectCode = (
   }
 };
 
-interface Options {
-  hotKeys?: HotKey[] | false;
-  showSwitch?: boolean;
-  autoToggle?: boolean;
+interface Options extends CodeOptions {
+  close?: boolean;
 }
+
 class WebpackCodeInspectorPlugin {
   options: Options;
 
@@ -70,6 +75,12 @@ class WebpackCodeInspectorPlugin {
   }
 
   apply(compiler) {
+    isFirstLoad = true;
+
+    if (this.options.close) {
+      return;
+    }
+
     // 仅在开发环境下使用
     if (
       compiler?.options?.mode !== 'development' &&

--- a/packages/webpack-plugin/types/index.d.ts
+++ b/packages/webpack-plugin/types/index.d.ts
@@ -1,8 +1,6 @@
-import { HotKey } from 'code-inspector-core';
-interface Options {
-    hotKeys?: HotKey[] | false;
-    showSwitch?: boolean;
-    autoToggle?: boolean;
+import { CodeOptions } from 'code-inspector-core';
+interface Options extends CodeOptions {
+    close?: boolean;
 }
 declare class WebpackCodeInspectorPlugin {
     options: Options;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@types/node':
         specifier: ^16.0.1
         version: 16.18.12
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
       typescript:
         specifier: ^4.9.3
         version: 4.9.5
@@ -3540,7 +3543,7 @@ packages:
       cssnano: 4.1.11
       debug: 4.3.4(supports-color@6.1.0)
       default-gateway: 5.0.5
-      dotenv: registry.npmmirror.com/dotenv@8.6.0
+      dotenv: 8.6.0
       dotenv-expand: registry.npmmirror.com/dotenv-expand@5.1.0
       file-loader: registry.npmmirror.com/file-loader@4.3.0(webpack@4.46.0)
       fs-extra: registry.npmmirror.com/fs-extra@7.0.1
@@ -5714,6 +5717,16 @@ packages:
   /dotenv@16.1.4:
     resolution: {integrity: sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==}
     engines: {node: '>=12'}
+    dev: true
+
+  /dotenv@16.3.1:
+    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
     dev: true
 
   /easy-stack@1.0.1:
@@ -18276,13 +18289,6 @@ packages:
     version: 10.0.0
     engines: {node: '>=10'}
     dev: false
-
-  registry.npmmirror.com/dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dotenv/-/dotenv-8.6.0.tgz}
-    name: dotenv
-    version: 8.6.0
-    engines: {node: '>=10'}
-    dev: true
 
   registry.npmmirror.com/dotignore@0.1.2:
     resolution: {integrity: sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==, registry: https://registry.npmjs.org/, tarball: https://registry.npmmirror.com/dotignore/-/dotignore-0.1.2.tgz}


### PR DESCRIPTION
- Fix the issue of full page refresh during hot updates when used in webpack
- Added the `needEnvInspector` parameter to support scenarios where the plugin only takes effect when `CODE_INSPECTOR=true` is configured in `.local.env`