### PR TITLE
fix: fix fragment warning.

### DIFF
--- a/demos/webpack-react/src/App.tsx
+++ b/demos/webpack-react/src/App.tsx
@@ -23,6 +23,10 @@ function App() {
         <p>p1</p>
         <p>p2</p>
       </React.Fragment>
+      <Fragment>
+        <p>p1</p>
+        <p>p2</p>
+      </Fragment>
     </div>
   );
 }

--- a/packages/core/src/server/content-enhance.ts
+++ b/packages/core/src/server/content-enhance.ts
@@ -38,6 +38,7 @@ export function enhanceCode(params: EnhanceCodeParams) {
       'transition-group',
       'transitiongroup',
       'suspense',
+      "fragment"
     ];
 
     if (fileType === 'vue') {


### PR DESCRIPTION
`React.Fragment` ast different with `Fragment `.
[the same as](https://github.com/zh-lx/code-inspector/issues/44) just compat it