### PR TITLE
fix: prevent printing error when the project is not in git

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -12,10 +12,12 @@ import chalk from 'chalk';
 function getProjectRoot(): string {
   try {
     const command = 'git rev-parse --show-toplevel';
-    const gitRoot = execSync(command, { encoding: 'utf-8' }).trim();
+    const gitRoot = execSync(command, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
     return gitRoot;
   } catch (error) {
-    console.error(error);
     return '';
   }
 }


### PR DESCRIPTION
close #268 