### PR TITLE
demo: Fix the issue where the local Svelte demo fails to run

### DIFF
--- a/demos/vite-svelte/.gitignore
+++ b/demos/vite-svelte/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+!lib

--- a/demos/vite-svelte/src/lib/Counter.svelte
+++ b/demos/vite-svelte/src/lib/Counter.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    let count: number = 0;
+    const increment = () => {
+        count += 1;
+    };
+</script>
+
+<button on:click={increment}>
+    count is {count}
+</button>
+
+<h1>test</h1>

--- a/demos/vite-svelte/src/lib/Counter.svelte
+++ b/demos/vite-svelte/src/lib/Counter.svelte
@@ -8,5 +8,3 @@
 <button on:click={increment}>
     count is {count}
 </button>
-
-<h1>test</h1>


### PR DESCRIPTION
由于根目录的 [.gitignore](https://github.com/zh-lx/code-inspector/blob/main/.gitignore#L3) 忽略了 lib 目录，导致 svelte 的引用目录在之前没有成功上传，导致 demo 无法运行，现在加上缺失的文件，并让 svelte demo 项目不再忽略 lib。 