### PR TITLE
feat: open in git remote

### DIFF
--- a/packages/core/src/shared/git-utils.ts
+++ b/packages/core/src/shared/git-utils.ts
@@ -1,0 +1,53 @@
+import { execSync } from 'child_process';
+
+export function getGitRemoteUrl(): string {
+  try {
+    const command = 'git config --get remote.origin.url';
+    const remoteUrl = execSync(command, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    
+    // Convert SSH URL to HTTPS URL if needed
+    if (remoteUrl.startsWith('git@')) {
+      return remoteUrl
+        .replace(/^git@([^:]+):/, 'https://$1/')
+        .replace(/\.git$/, '');
+    }
+    
+    // Handle gitlab@gitlab.xxx.net format
+    if (remoteUrl.startsWith('gitlab@')) {
+      return remoteUrl
+        .replace(/^gitlab@([^:]+):/, 'https://$1/')
+        .replace(/\.git$/, '');
+    }
+    
+    return remoteUrl.replace(/\.git$/, '');
+  } catch (error) {
+    return '';
+  }
+}
+
+export function getCurrentBranch(): string {
+  try {
+    const command = 'git rev-parse --abbrev-ref HEAD';
+    return execSync(command, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    return 'main'; // Default to main if we can't get the branch
+  }
+}
+
+export function getProjectRootPath(): string {
+  try {
+    const command = 'git rev-parse --show-toplevel';
+    return execSync(command, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    return '';
+  }
+}

--- a/packages/core/src/shared/type.ts
+++ b/packages/core/src/shared/type.ts
@@ -157,4 +157,9 @@ export type CodeOptions = {
    * @en The type of path injected into the DOM, the default value is `absolute`, which means the path is relative to the project root directory
    */
   pathType?: PathType;
+  /**
+   * @zh 是否在 Git 远端中打开文件而不是本地 IDE
+   * @en Whether to open files in Git remote instead of local IDE
+   */
+  openInGit?: boolean;
 };

--- a/packages/core/types/client/index.d.ts
+++ b/packages/core/types/client/index.d.ts
@@ -28,6 +28,7 @@ export declare class CodeInspectorComponent extends LitElement {
     locate: boolean;
     copy: boolean | string;
     ip: string;
+    openInGit: boolean;
     position: {
         top: number;
         right: number;
@@ -94,6 +95,7 @@ export declare class CodeInspectorComponent extends LitElement {
     removeGlobalCursorStyle: () => void;
     sendXHR: () => void;
     sendImg: () => void;
+    handleOpenInGit(filePath: string, line?: number): void;
     trackCode: () => void;
     copyToClipboard(text: string): void;
     moveSwitch: (e: MouseEvent | TouchEvent) => void;

--- a/packages/core/types/server/use-client.d.ts
+++ b/packages/core/types/server/use-client.d.ts
@@ -2,6 +2,7 @@ import type { CodeOptions, RecordInfo } from '../shared';
 export declare const clientJsPath: string;
 export declare function getInjectedCode(options: CodeOptions, port: number): string;
 export declare function getWebComponentCode(options: CodeOptions, port: number): string;
+export declare function injectGitCode(options: CodeOptions): string;
 export declare function getEliminateWarningCode(): string;
 export declare function getHidePathAttrCode(): string;
 export declare function getCodeWithWebComponent({ options, record, file, code, inject, }: {

--- a/packages/core/types/shared/git-utils.d.ts
+++ b/packages/core/types/shared/git-utils.d.ts
@@ -1,0 +1,3 @@
+export declare function getGitRemoteUrl(): string;
+export declare function getCurrentBranch(): string;
+export declare function getProjectRootPath(): string;

--- a/packages/core/types/shared/type.d.ts
+++ b/packages/core/types/shared/type.d.ts
@@ -154,5 +154,10 @@ export type CodeOptions = {
      * @en The type of path injected into the DOM, the default value is `absolute`, which means the path is relative to the project root directory
      */
     pathType?: PathType;
+    /**
+     * @zh 是否在 Git 远端中打开文件而不是本地 IDE
+     * @en Whether to open files in Git remote instead of local IDE
+     */
+    openInGit?: boolean;
 };
 export {};


### PR DESCRIPTION
Support opening the source code in the Git remote. 
This way, it can be enabled in testing or staging environments without relying on the server-side.
