### PR TITLE
chore: add postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "version:minor": "node ./scripts/version minor",
     "version:patch": "node ./scripts/version patch",
     "version:prod": "node ./scripts/version prod",
-    "version:beta": "node ./scripts/version beta"
+    "version:beta": "node ./scripts/version beta",
+    "postinstall": "pnpm build"
   },
   "private": true,
   "main": "index.js",


### PR DESCRIPTION
在根目录执行`pnpm i`会触发`demo/nuxt`文件夹下的`postinstall`脚本，此时，若code-inspector-plugin没有构建会出现报错。

![image](https://github.com/user-attachments/assets/eb4ef8c8-f27b-4bdf-96e5-32638df05591)
