### PR TITLE
chore: add onlyBuiltDependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,19 @@
 packages:
-  - 'packages/*'
-  - 'demos/*'
-  - 'docs/*'
+  - packages/*
+  - demos/*
+  - docs/*
+onlyBuiltDependencies:
+  - '@swc/core'
+  - bufferutil
+  - core-js
+  - core-js-pure
+  - ejs
+  - esbuild
+  - fsevents
+  - protobufjs
+  - sharp
+  - styled-components
+  - svelte-preprocess
+  - utf-8-validate
+  - vue-demi
+  - yorkie


### PR DESCRIPTION
pnpm 10 no longer executes scripts by default and needs to be specified manually.

To ease management and avoid conflicts with npm, pnpm supports moving all configurations to the pnpm-workspace.yaml file. For more [github.com/orgs/pnpm/discussions/9037](https://github.com/orgs/pnpm/discussions/9037)