### PR TITLE
The plugin should be called before `vite/plugin-react` or `vite/plugin-react-swc` for accurate sourcemaps

### DIFF
--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -115,5 +115,22 @@ export function ViteCodeInspectorPlugin(options: Options) {
         `<head><script type="module">\n${code}\n</script>`
       );
     },
+    config(config) {
+      // The "name" field for @vitejs/plugin-react and @vitejs/plugin-react-swc respectively
+      const reactPluginNames = ['vite:react', 'vite:react-swc'];
+
+      const plugins = config.plugins ?? [];
+      const selfIndex = plugins.findIndex(p => p?.name === PluginName);
+
+      const reactIndex = plugins.findIndex(p => reactPluginNames.includes(p?.name));
+
+      if (selfIndex > -1 && reactIndex > -1 && selfIndex > reactIndex) {
+        // Move self before react
+        const [selfPlugin] = plugins.splice(selfIndex, 1);
+        plugins.splice(reactIndex, 0, selfPlugin);
+      }
+
+      config.plugins = plugins;
+    },
   };
 }


### PR DESCRIPTION
**Context: React + Vite**

I noticed that when the plugin is called after one of  `@vitejs/plugin-react` or `@vitejs/plugin-react-swc`, it may result in inaccurate sourcemaps. I have manually tested this in 2 of my local apps. Listing `code-inspector-plugin` before or after these two plugins was resulting in two different DOM sourcemaps. The filePath information was always correct, but the line number information was changing immensely, in the scale of tens of lines, depending on the size of the file. 

So I have kindly made a small addition that only affects the Vite plugin.

I'm using the following versions:
```
  "react": "^18.2.0",
  "react-dom": "^18.2.0",
  "vite": "^5.0.8",
  "@vitejs/plugin-react-swc": "^3.10.2",
  "@vitejs/plugin-react": "^4.2.1",
```

I didn't test this thoroughly, however if this caveat is correct, it can be added to the  documentation site as well. (Sorry if I missed an already existing one)

Correct way to use it:
```js
import { defineConfig } from 'vite';
import react from '@vitejs/plugin-react-swc'
import { codeInspectorPlugin } from 'code-inspector-plugin';

export default defineConfig({
  plugins: [
    codeInspectorPlugin({
      bundler: 'vite',
    }),
    react(), // This should come AFTER the codeInspectorPlugin!
  ],
});
```

Thank you!