### PR TITLE
fix: use clientX/clientY for fixed positioned inspector dropdown

### DIFF
--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -463,7 +463,7 @@ export class CodeInspectorComponent extends LitElement {
       const nodePath = e.composedPath() as HTMLElement[];
       const nodeTree = this.generateNodeTree(nodePath);
 
-      this.renderLayerPanel(nodeTree, { x: e.pageX, y: e.pageY });
+      this.renderLayerPanel(nodeTree, { x: e.clientX, y: e.clientY });
     }
   };
 


### PR DESCRIPTION
## Problem

When the page is scrolled, the inspector dropdown (layer panel) appears at an incorrect position. The offset increases the further down you scroll.

## Root Cause

The `#inspector-layers` element uses `position: fixed` (line 1017) but receives `pageX`/`pageY` coordinates (line 466) which include scroll offset. Fixed positioned elements need viewport-relative coordinates.

## Solution

Changed from `e.pageX`/`e.pageY` to `e.clientX`/`e.clientY` which provide viewport-relative coordinates that work correctly with fixed positioning.

## Steps to Reproduce

1. Create any React/Vue/Next.js project with scrollable content
2. Install and configure code-inspector-plugin
3. Add content that makes the page scrollable (e.g., divs with height: 1800px)
4. Start the dev server
5. Scroll down the page
6. Hold Alt+Shift (Windows) or Option+Shift (Mac) and right-click on an element
7. **Bug**: The dropdown appears offset from the cursor by the scroll amount

### Quick Reproduction Example (Vite + React)

```bash
npm create vite@latest test-app -- --template react-ts
cd test-app
npm install
npm install -D code-inspector-plugin
```

Add to `vite.config.ts`:
```ts
import { codeInspectorPlugin } from 'code-inspector-plugin'

export default defineConfig({
  plugins: [
    react(),
    codeInspectorPlugin({
      bundler: 'vite',
      showSwitch: true,
    })
  ],
})
```

Replace `src/App.tsx` with:
```tsx
function App() {
  return (
    <>
      <div style={{ height: '1800px', background: '#3178c6', color: 'white', padding: '2rem' }}>
        <h1>Scroll down and test code inspector</h1>
      </div>
      <div style={{ height: '1800px', background: '#42b883', color: 'white', padding: '2rem' }}>
        <h1>The dropdown will appear at wrong position</h1>
      </div>
    </>
  )
}
```

## Testing

Before: Dropdown appears offset by the scroll amount
After: Dropdown appears at the correct position next to cursor

Tested with:
- Next.js + Webpack
- Vite + React
- Both show the same issue before the fix