### PR TITLE
fix(turbopack): restrict default pattern to app directory to prevent middleware crashes

### DIFF
--- a/demos/turbopack-next15/package.json
+++ b/demos/turbopack-next15/package.json
@@ -9,22 +9,22 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.4.4"
+    "next": "15.5.3",
+    "react": "19.1.1",
+    "react-dom": "19.1.1"
   },
   "devDependencies": {
-    "typescript": "^5",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
-    "eslint": "^9",
-    "eslint-config-next": "15.4.4",
-    "@eslint/eslintrc": "^3",
+    "@eslint/eslintrc": "^3.3.1",
+    "@mdx-js/loader": "^3.1.1",
+    "@next/mdx": "15.5.3",
+    "@tailwindcss/postcss": "^4.1.13",
+    "@types/node": "^24.3.1",
+    "@types/react": "^19.1.12",
+    "@types/react-dom": "^19.1.9",
     "code-inspector-plugin": "workspace:^",
-    "@next/mdx": "15.4.4",
-    "@mdx-js/loader": "^3.1.0"
+    "eslint": "^9.35.0",
+    "eslint-config-next": "15.5.3",
+    "tailwindcss": "^4.1.13",
+    "typescript": "^5.9.2"
   }
 }

--- a/demos/turbopack-next15/src/middleware.ts
+++ b/demos/turbopack-next15/src/middleware.ts
@@ -1,0 +1,15 @@
+// Middleware file to verify turbopack compatibility
+// 
+// ⚠️ This file should be REMOVED once Turbopack fixes the middleware issue ⚠️
+// 
+// With the improved pattern '**/app/**/*.{jsx,tsx,js,ts,mjs,mts}' in the turbopack plugin,
+// code-inspector only processes files in app directories, naturally excluding middleware files.
+// This prevents the Turbopack crash issue by default.
+// 
+// This is still a workaround. Track the issues for removal:
+// - https://github.com/vercel/next.js/issues/79592
+// - https://github.com/zh-lx/code-inspector/issues/357
+
+export function middleware() {
+  // Empty middleware - its presence is enough to test the workaround
+}

--- a/packages/turbopack/src/index.ts
+++ b/packages/turbopack/src/index.ts
@@ -36,7 +36,7 @@ export function TurbopackCodeInspectorPlugin(
   const WebpackDistDir = path.resolve(WebpackEntry, '..');
 
   return {
-    '**/*.{jsx,tsx,js,ts,mjs,mts}': {
+    '**/app/**/*.{jsx,tsx,js,ts,mjs,mts}': {
       loaders: [
         {
           loader: `${WebpackDistDir}/loader.js`,


### PR DESCRIPTION
## Summary
This PR addresses the Turbopack middleware crash issue with code-inspector plugin.

- Changes default pattern from `**/*.{jsx,tsx,js,ts,mjs,mts}` to `**/app/**/*.{jsx,tsx,js,ts,mjs,mts}`
- Restricts code-inspector to only process files in app directories
- Naturally excludes middleware files (typically at root/src level), preventing Turbopack crashes

## Related Issues
- Next.js/Turbopack issue: https://github.com/vercel/next.js/issues/79592
- Code Inspector issue: https://github.com/zh-lx/code-inspector/issues/357

## Configuration Workaround
Users can also fix this issue immediately in their `next.config.ts` without waiting for this PR:

```typescript
const nextConfig: NextConfig = {
  turbopack: {
    rules: {
      '**/app/**/*.{jsx,tsx,js,ts,mjs,mts}': Object.values(codeInspectorPlugin({ bundler: 'turbopack' }))[0]
    } as any
  },
};
```

## Test Plan
- [x] Tested with Next.js 15 demo app containing middleware
- [x] No crashes with middleware present
- [x] Code inspector works correctly for app directory files

This is a temporary workaround until Turbopack resolves the underlying issue.