### PR TITLE
fix: restore full pattern after Next.js 15.6 Turbopack fix

### DIFF
--- a/demos/turbopack-next15/package.json
+++ b/demos/turbopack-next15/package.json
@@ -9,22 +9,22 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "15.5.3",
+    "next": "15.6.0-canary.38",
     "react": "19.1.1",
     "react-dom": "19.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "@mdx-js/loader": "^3.1.1",
-    "@next/mdx": "15.5.3",
+    "@next/mdx": "15.6.0-canary.38",
     "@tailwindcss/postcss": "^4.1.13",
-    "@types/node": "^24.3.1",
-    "@types/react": "^19.1.12",
+    "@types/node": "^24.6.1",
+    "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
     "code-inspector-plugin": "workspace:^",
-    "eslint": "^9.35.0",
-    "eslint-config-next": "15.5.3",
+    "eslint": "^9.36.0",
+    "eslint-config-next": "15.6.0-canary.38",
     "tailwindcss": "^4.1.13",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.3"
   }
 }

--- a/demos/turbopack-next15/src/middleware.ts
+++ b/demos/turbopack-next15/src/middleware.ts
@@ -1,15 +1,9 @@
-// Middleware file to verify turbopack compatibility
-// 
-// ⚠️ This file should be REMOVED once Turbopack fixes the middleware issue ⚠️
-// 
-// With the improved pattern '**/app/**/*.{jsx,tsx,js,ts,mjs,mts}' in the turbopack plugin,
-// code-inspector only processes files in app directories, naturally excluding middleware files.
-// This prevents the Turbopack crash issue by default.
-// 
-// This is still a workaround. Track the issues for removal:
-// - https://github.com/vercel/next.js/issues/79592
-// - https://github.com/zh-lx/code-inspector/issues/357
+// Middleware file to verify code-inspector works with middleware present
+//
+// This file proves that code-inspector is compatible with Next.js middleware.
+// The middleware crash bug existed in Next.js 15.4.4 and below but has been
+// fixed in Next.js 15.6.0-canary.38 and later versions.
 
 export function middleware() {
-  // Empty middleware - its presence is enough to test the workaround
+  // Empty middleware - its presence is enough to verify compatibility
 }

--- a/demos/turbopack-next15/tsconfig.json
+++ b/demos/turbopack-next15/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/turbopack/src/index.ts
+++ b/packages/turbopack/src/index.ts
@@ -35,32 +35,8 @@ export function TurbopackCodeInspectorPlugin(
   }
   const WebpackDistDir = path.resolve(WebpackEntry, '..');
 
-  // according to: https://nextjs.org/docs/app/getting-started/project-structure#routing-files
-  const validFiles = [
-    '*.jsx',
-    '*.tsx',
-    'layout.js',
-    'layout.ts',
-    'page.js',
-    'page.ts',
-    'loading.js',
-    'loading.ts',
-    'not-found.js',
-    'not-found.ts',
-    'error.js',
-    'error.ts',
-    'global-error.js',
-    'global-error.ts',
-    'template.js',
-    'template.ts',
-    'default.js',
-    'default.ts',
-  ];
-
-  const matchFiles = `**/{${validFiles.join(',')}}`;
-
   return {
-    [matchFiles]: {
+    '**/*.{jsx,tsx,js,ts,mjs,mts}': {
       loaders: [
         {
           loader: `${WebpackDistDir}/loader.js`,
@@ -68,7 +44,6 @@ export function TurbopackCodeInspectorPlugin(
             ...options,
             record,
           },
-          ...(options.enforcePre === false ? {} : { enforce: 'pre' }),
         },
         {
           loader: `${WebpackDistDir}/inject-loader.js`,
@@ -76,7 +51,6 @@ export function TurbopackCodeInspectorPlugin(
             ...options,
             record,
           },
-          enforce: 'pre',
         },
       ],
     },


### PR DESCRIPTION
## Summary

This PR proposes reverting the Turbopack pattern restrictions introduced in #398 and #399 once Next.js 15.6.0 is released as stable.

The underlying middleware crash bug has been fixed in Next.js 15.6.0-canary.22, allowing us to restore full code-inspector coverage across the entire codebase by returning to the original `**/*.{jsx,tsx,js,ts,mjs,mts}` pattern.

## Context

**Previous workarounds (no longer needed):**
- **PR #398**: Restricted to `**/app/**/*.{jsx,tsx,js,ts,mjs,mts}`
  - **Problem**: Missed `components/`, `lib/`, `hooks/`, etc.
- **PR #399**: Changed to `**/*.{jsx,tsx}` + specific Next.js routing files (layout.js, page.ts, etc.)
  - Excluded all regular `.js`, `.ts`, `.mjs`, `.mts` files to avoid middleware

These restrictions were necessary to avoid the Turbopack middleware crash documented in:
- https://github.com/vercel/next.js/issues/83613
- https://github.com/zh-lx/code-inspector/issues/357

**The fix:**
The underlying Turbopack bug has been fixed in Next.js 15.6.0-canary.22 via https://github.com/vercel/next.js/pull/83683

## Changes

1. **Reverts to original full pattern**: `**/*.{jsx,tsx,js,ts,mjs,mts}`
   - Restores coverage for all file types across the entire codebase
   - No longer restricted by directory or file extension
   - Works everywhere: `components/`, `lib/`, `hooks/`, `app/`, etc.

2. **Removes `enforce` property**: Not supported in Next.js 15.6+

3. **Updates demo to Next.js 15.6.0-canary.38**: Proves the fix works

## Status

⚠️ **This is a placeholder PR for consideration** ⚠️

- Currently uses canary version `15.6.0-canary.38`
- Should be merged once `15.6.0` is released as stable
- Demonstrates that the original full pattern now works without crashes

## Testing

- ✅ Middleware file present (previously caused crash)
- ✅ Code inspector works across entire codebase
- ✅ No Turbopack errors with full pattern
- ✅ Demo runs successfully with `pnpm dev`
