### PR TITLE
fix: append CJS Module for next.js page router

### DIFF
--- a/packages/core/src/server/use-client.ts
+++ b/packages/core/src/server/use-client.ts
@@ -57,7 +57,7 @@ export function getInjectedCode(
   code = `/* eslint-disable */ ` + code.replace(/\n/g, '');
   if (isNextjs) {
     code += `
-    export default function ${NextEmptyElementName}() {
+    module.exports = function ${NextEmptyElementName}() {
       return null;
     }
     `;


### PR DESCRIPTION
fix #404 

`append-code-5678.js` is a CJS file, so CodeInspectorEmptyElement should be exported in CJS format. It’s currently exported in ESM format, causing errors in Next.js Page Router.

<img width="784" height="287" alt="Screenshot 2025-10-13 at 10 22 23 PM" src="https://github.com/user-attachments/assets/59c94327-1ca6-4260-8a04-cfa014e894e5" />