### PR TITLE
feat(client): enhance right-click context menu with mode support

### DIFF
--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -707,16 +707,59 @@ export class CodeInspectorComponent extends LitElement {
     }
   }
 
+  showNotification(message: string, type: 'success' | 'error' = 'success') {
+    const notification = document.createElement('div');
+    notification.className = `code-inspector-notification code-inspector-notification-${type}`;
+    notification.textContent = message;
+    document.body.appendChild(notification);
+
+    // Trigger animation
+    requestAnimationFrame(() => {
+      notification.classList.add('code-inspector-notification-show');
+    });
+
+    // Remove after 2 seconds
+    setTimeout(() => {
+      notification.classList.remove('code-inspector-notification-show');
+      setTimeout(() => {
+        document.body.removeChild(notification);
+      }, 300);
+    }, 2000);
+  }
+
   copyToClipboard(text: string) {
-    if (typeof navigator?.clipboard?.writeText === 'function') {
-      navigator.clipboard.writeText(text);
-    } else {
+    try {
+      if (typeof navigator?.clipboard?.writeText === 'function') {
+        navigator.clipboard.writeText(text).then(() => {
+          this.showNotification('✓ Copied to clipboard');
+        }).catch(() => {
+          this.fallbackCopy(text);
+        });
+      } else {
+        this.fallbackCopy(text);
+      }
+    } catch (error) {
+      this.fallbackCopy(text);
+    }
+  }
+
+  private fallbackCopy(text: string) {
+    try {
       const textarea = document.createElement('textarea');
       textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
       document.body.appendChild(textarea);
       textarea.select();
-      document.execCommand('copy');
+      const success = document.execCommand('copy');
       document.body.removeChild(textarea);
+      if (success) {
+        this.showNotification('✓ Copied to clipboard');
+      } else {
+        this.showNotification('✗ Copy failed', 'error');
+      }
+    } catch (error) {
+      this.showNotification('✗ Copy failed', 'error');
     }
   }
 
@@ -1505,6 +1548,45 @@ export class CodeInspectorComponent extends LitElement {
       cursor: pointer;
     }
   `;
+}
+
+// Global notification styles
+if (!document.getElementById('code-inspector-notification-styles')) {
+  const notificationStyles = document.createElement('style');
+  notificationStyles.id = 'code-inspector-notification-styles';
+  notificationStyles.textContent = `
+    .code-inspector-notification {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      z-index: 99999999999999999;
+      padding: 12px 16px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-weight: 500;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      opacity: 0;
+      transform: translateY(-10px);
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      pointer-events: none;
+    }
+    .code-inspector-notification-success {
+      background: hsl(143, 85%, 96%);
+      color: hsl(140, 100%, 27%);
+      border: 1px solid hsl(145, 92%, 91%);
+    }
+    .code-inspector-notification-error {
+      background: hsl(0, 93%, 94%);
+      color: hsl(0, 84%, 40%);
+      border: 1px solid hsl(0, 93%, 94%);
+    }
+    .code-inspector-notification-show {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  `;
+  document.head.appendChild(notificationStyles);
 }
 
 if (!customElements.get('code-inspector-component')) {

--- a/packages/core/types/client/index.d.ts
+++ b/packages/core/types/client/index.d.ts
@@ -144,7 +144,9 @@ export declare class CodeInspectorComponent extends LitElement {
     private handleModeShortcut;
     private printModeChange;
     private getActionLabel;
+    showNotification(message: string, type?: 'success' | 'error'): void;
     copyToClipboard(text: string): void;
+    private fallbackCopy;
     handleDrag: (e: MouseEvent | TouchEvent) => void;
     isSamePositionNode: (node1: HTMLElement, node2: HTMLElement) => boolean;
     handleMouseMove: (e: MouseEvent | TouchEvent) => Promise<void>;


### PR DESCRIPTION
## 🎯 What's This PR About?

This PR enhances the right-click context menu (layer panel) to respect the current action mode, building on top of the recently merged mode switching feature (#409).

## ✨ New Features

### 1. **Dynamic Layer Panel Title**
- Shows current mode in the panel title: "Click node · Copy Path" / "Click node · Open in IDE"
- Users always know what will happen when they click a node

### 2. **Mode-Aware Node Actions**
- Right-click node actions now respect the current `defaultAction` setting
- Previously: Always opened IDE (hardcoded `locate` action)
- Now: Follows the same mode as left-click (copy/locate/target/all)

### 3. **Visual Feedback for Copy Actions**
- Toast notifications when copying file paths
- Success: "✓ Copied to clipboard"
- Error: "✗ Copy failed"
- Styled with shadcn-inspired design

## 🔧 Technical Changes

### Core Changes (packages/core/src/client/index.ts)

1. **`handleClickTreeNode` method** (Line ~984-991):
   - Before: `this.trackCode('locate')` (hardcoded)
   - After: `this.trackCode(this.getDefaultAction())` (respects current mode)

2. **Layer panel title** (Line ~1286):
   - Before: Static text "click node to open editor"
   - After: Dynamic `Click node · ${this.getActionLabel(this.getDefaultAction())}`

3. **Notification system** (Line ~710-764):
   - New `showNotification()` method for toast messages
   - Enhanced `copyToClipboard()` with success/error feedback
   - Fallback copy mechanism for older browsers
   - Global styles for notification UI

## 🎬 User Experience

**Before:**
- Left-click: Respects mode (copy/locate)
- Right-click: Always opens IDE ❌ Inconsistent

**After:**
- Left-click: Respects mode (copy/locate)
- Right-click: Respects mode (copy/locate) ✅ Consistent
- Copy actions show visual feedback ✅ Better UX

## 🧪 Testing

Built and tested with:
```bash
cd packages/core && pnpm build
```

All builds pass successfully.

## 📝 Related

- Builds on #409 (mode switching feature)
- Completes the unified interaction model
- Especially useful for AI-first workflows where copy mode is the primary action

## 🤝 Motivation

This PR came from real usage feedback: when users switch to copy mode for AI workflows, they expect both left-click and right-click to behave consistently. The layer panel is a powerful feature for navigating component hierarchies, and it should respect the user's chosen workflow mode.

---

**For maintainers**: This is a clean enhancement on top of the merged mode switching feature. No breaking changes, purely additive functionality that makes the interaction model more consistent.