### PR TITLE
fix(server): normalize file path to ensure path stays within ProjectRootPath

### DIFF
--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -50,7 +50,7 @@ export function createServer(
     const params = new URLSearchParams(req.url.slice(1));
     let file = decodeURIComponent(params.get('file') as string);
     if (ProjectRootPath && !path.isAbsolute(file)) {
-      file = `${ProjectRootPath}/${file}`;
+      file = path.resolve(ProjectRootPath, file);
     }
     if (
       options?.pathType === 'relative' &&


### PR DESCRIPTION
fix http://localhost:port?file=../../../../etc/passwd can open passwd

* Use path.resolve(ProjectRootPath, file) to normalize incoming paths
* Ensure the resolved path stays within ProjectRootPath
* Block traversal patterns like ?file=../../../../etc/passwd