### PR TITLE
feat: add launchType option for IDE launching

### DIFF
--- a/docs/en/api/basic.md
+++ b/docs/en/api/basic.md
@@ -55,3 +55,11 @@ codeInspectorPlugin({
 - Optional. Default value is `true`
 - Type: `boolean`
 - Description: Used with `showSwitch: true`. After triggering the IDE jump feature, it automatically turns off the `switch` functionality. (This is mainly to prevent accidental triggering of the source code location feature when users switch back to the page and it gains focus.)
+
+## launchType <Badge type="tip" text="1.3.5+" vertical="middle" />
+
+- Optional. Default value is `exec`
+- Type: `exec | open`
+- Description: The method for launching the IDE. Only supports MacOS. If the editor is in the support list, it is strongly recommended to set `launchType: 'open'`. The support list can be found at: [which editor supports to be launched by open](https://github.com/zh-lx/launch-ide?tab=readme-ov-file#which-editor-supports-to-be-launched-by-open).
+  - `exec`, use the executable path to open the editor;
+  - `open` use `open "{editor}://file/xxx/main.jsx:10:20"` to open, it is fast and provides a very smooth experience

--- a/docs/zh/api/basic.md
+++ b/docs/zh/api/basic.md
@@ -55,3 +55,11 @@ codeInspectorPlugin({
 - 可选项。默认值为 `true`
 - 类型：`boolean`
 - 说明：配合 `showSwitch: true` 使用，触发了跳转 IDE 功能后，会自动将 `switch` 的功能关闭。（主要是为了防止用户切回页面后，页面聚焦时会直接误触发源码定位功能。）
+
+## launchType <Badge type="tip" text="1.3.5+" vertical="middle" />
+
+- 可选项。默认值为 `exec`
+- 类型：`exec | open`
+- 说明：启动 IDE 的方式。仅支持 MacOS，如果 editor 在支持列表内，强烈建议设置 `launchType: 'open'`。editor 支持列表请参考：[which editor supports to be launched by open](https://github.com/zh-lx/launch-ide?tab=readme-ov-file#which-editor-supports-to-be-launched-by-open)。
+  - `exec`，使用可执行路径打开 editor；
+  - `open` 使用 `open "{editor}://file/xxx/main.jsx:10:20"` 方式来打开，速度快且体验更丝滑

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fs-extra": "^10.0.0",
     "husky": "^8.0.3",
     "jsdom": "^25.0.1",
-    "launch-ide": "1.3.1",
+    "launch-ide": "1.4.0",
     "rimraf": "^5.0.5",
     "vitest": "^2.1.4",
     "zip-a-folder": "^3.1.7"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
     "@vue/compiler-dom": "^3.5.13",
     "chalk": "^4.1.1",
     "dotenv": "^16.1.4",
-    "launch-ide": "1.3.1",
+    "launch-ide": "1.4.0",
     "portfinder": "^1.0.28"
   },
   "devDependencies": {

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -87,6 +87,7 @@ export function createServer(
       method: options?.openIn,
       format: options?.pathFormat,
       rootDir: record?.envDir,
+      type: options?.launchType,
     });
   });
 

--- a/packages/core/src/shared/type.ts
+++ b/packages/core/src/shared/type.ts
@@ -185,4 +185,18 @@ export type CodeOptions = {
    * @en Whether to enable the server function. The default value is `open`, which means enabling the server function. The server function must be enabled when using the code location function, and it can be closed when building online only to view the dom path.
    */
   server?: 'open' | 'close';
+  /**
+   * @zh 启动 IDE 的方式。默认为 `exec`
+   * - exec: 使用可执行路径打开 editor
+   * - open: 使用 `open "{editor}://file/xxx/main.jsx:10:20"` 方式来打开。速度快且体验非常丝滑
+   *
+   * 仅支持 MacOS，如果 editor 在支持列表内，强烈建议设置 `launchType: 'open'`。editor 支持列表请参考：[which editor supports to be launched by open](https://github.com/zh-lx/launch-ide?tab=readme-ov-file#which-editor-supports-to-be-launched-by-open)。
+   *
+   * @en The method for launching the IDE. Default value is `exec`
+   * - exec: Use the executable path to open the editor
+   * - open: Use `open "{editor}://file/xxx/main.jsx:10:20"` to open. It is fast and provides a very smooth experience
+   *
+   * Only supports MacOS. If the editor is in the support list, it is strongly recommended to set `launchType: 'open'`. The support list can be found at: [which editor supports to be launched by open](https://github.com/zh-lx/launch-ide?tab=readme-ov-file#which-editor-supports-to-be-launched-by-open).
+   */
+  launchType?: 'exec' | 'open';
 };

--- a/packages/core/types/shared/type.d.ts
+++ b/packages/core/types/shared/type.d.ts
@@ -181,5 +181,19 @@ export type CodeOptions = {
      * @en Whether to enable the server function. The default value is `open`, which means enabling the server function. The server function must be enabled when using the code location function, and it can be closed when building online only to view the dom path.
      */
     server?: 'open' | 'close';
+    /**
+     * @zh 启动 IDE 的方式。默认为 `exec`
+     * - exec: 使用可执行路径打开 editor
+     * - open: 使用 `open "{editor}://file/xxx/main.jsx:10:20"` 方式来打开。速度快且体验非常丝滑
+     *
+     * 仅支持 MacOS，如果 editor 在支持列表内，强烈建议设置 `launchType: 'open'`。editor 支持列表请参考：[which editor supports to be launched by open](https://github.com/zh-lx/launch-ide?tab=readme-ov-file#which-editor-supports-to-be-launched-by-open)。
+     *
+     * @en The method for launching the IDE. Default value is `exec`
+     * - exec: Use the executable path to open the editor
+     * - open: Use `open "{editor}://file/xxx/main.jsx:10:20"` to open. It is fast and provides a very smooth experience
+     *
+     * Only supports MacOS. If the editor is in the support list, it is strongly recommended to set `launchType: 'open'`. The support list can be found at: [which editor supports to be launched by open](https://github.com/zh-lx/launch-ide?tab=readme-ov-file#which-editor-supports-to-be-launched-by-open).
+     */
+    launchType?: 'exec' | 'open';
 };
 export {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^25.0.1
         version: 25.0.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
       launch-ide:
-        specifier: 1.3.1
-        version: 1.3.1
+        specifier: 1.4.0
+        version: 1.4.0
       rimraf:
         specifier: ^5.0.5
         version: 5.0.5
@@ -186,7 +186,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ^3.12.2
-        version: 3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@24.10.0)(bufferutil@4.0.8)(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.4.1)(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.4)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
+        version: 3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@24.10.0)(bufferutil@4.0.8)(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.4.1)(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
       vue:
         specifier: ^3.4.29
         version: 3.4.30(typescript@5.9.3)
@@ -957,8 +957,8 @@ importers:
         specifier: ^16.1.4
         version: 16.1.4
       launch-ide:
-        specifier: 1.3.1
-        version: 1.3.1
+        specifier: 1.4.0
+        version: 1.4.0
       portfinder:
         specifier: ^1.0.28
         version: 1.0.32(supports-color@6.1.0)
@@ -13252,8 +13252,8 @@ packages:
   launch-editor@2.8.0:
     resolution: {integrity: sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==}
 
-  launch-ide@1.3.1:
-    resolution: {integrity: sha512-opTthrpkuhi1Y8yFn6TWUeycyiI1aiZpVuTV4HQFUfVut7nMYGr5nQ8heYHrRJH2KYISLVYwz+QFRNZxFlbQmA==}
+  launch-ide@1.4.0:
+    resolution: {integrity: sha512-c2mcqZy7mNhzXiWoBFV0lDsEOfpSFGqqxKubPffhqcnv3GV0xpeGcHWLxYFm+jz1/5VAKp796QkyVV4++07eiw==}
 
   lazy-cache@1.0.4:
     resolution: {integrity: sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==}
@@ -24760,7 +24760,7 @@ snapshots:
       sirv: 2.0.4
       unimport: 3.7.2(rollup@4.16.4)
       vite: 5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)
-      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.16.4))(rollup@4.16.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
+      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.12.2(magicast@0.3.5)(rollup@4.16.4))(rollup@4.16.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
       vite-plugin-vue-inspector: 5.1.2(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
       which: 3.0.1
       ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
@@ -24775,6 +24775,33 @@ snapshots:
     dependencies:
       '@nuxt/schema': 3.12.2(rollup@4.16.4)
       c12: 1.11.1(magicast@0.3.4)
+      consola: 3.2.3
+      defu: 6.1.4
+      destr: 2.0.3
+      globby: 14.0.1
+      hash-sum: 2.0.0
+      ignore: 5.3.1
+      jiti: 1.21.6
+      klona: 2.0.6
+      knitwork: 1.1.0
+      mlly: 1.7.1
+      pathe: 1.1.2
+      pkg-types: 1.1.1
+      scule: 1.3.0
+      semver: 7.6.2
+      ufo: 1.5.3
+      unctx: 2.3.1
+      unimport: 3.7.2(rollup@4.16.4)
+      untyped: 1.4.2
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
+
+  '@nuxt/kit@3.12.2(magicast@0.3.5)(rollup@4.16.4)':
+    dependencies:
+      '@nuxt/schema': 3.12.2(rollup@4.16.4)
+      c12: 1.11.1(magicast@0.3.5)
       consola: 3.2.3
       defu: 6.1.4
       destr: 2.0.3
@@ -24816,9 +24843,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/telemetry@2.5.4(magicast@0.3.4)(rollup@4.16.4)':
+  '@nuxt/telemetry@2.5.4(magicast@0.3.5)(rollup@4.16.4)':
     dependencies:
-      '@nuxt/kit': 3.12.2(magicast@0.3.4)(rollup@4.16.4)
+      '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.16.4)
       ci-info: 4.0.0
       consola: 3.2.3
       create-require: 1.1.1
@@ -24840,9 +24867,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/vite-builder@3.12.2(@types/node@24.10.0)(eslint@9.39.1(jiti@2.6.1))(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.4)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(vue@3.4.30(typescript@5.9.3))':
+  '@nuxt/vite-builder@3.12.2(@types/node@24.10.0)(eslint@9.39.1(jiti@2.6.1))(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(vue@3.4.30(typescript@5.9.3))':
     dependencies:
-      '@nuxt/kit': 3.12.2(magicast@0.3.4)(rollup@4.16.4)
+      '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.16.4)
       '@rollup/plugin-replace': 5.0.7(rollup@4.16.4)
       '@vitejs/plugin-vue': 5.0.5(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))(vue@3.4.30(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 4.0.0(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))(vue@3.4.30(typescript@5.9.3))
@@ -30675,6 +30702,23 @@ snapshots:
       rc9: 2.1.2
     optionalDependencies:
       magicast: 0.3.4
+
+  c12@1.11.1(magicast@0.3.5):
+    dependencies:
+      chokidar: 3.6.0
+      confbox: 0.1.7
+      defu: 6.1.4
+      dotenv: 16.4.5
+      giget: 1.2.3
+      jiti: 1.21.6
+      mlly: 1.7.1
+      ohash: 1.1.3
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.1.1
+      rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.3.5
 
   cac@6.7.14: {}
 
@@ -37028,7 +37072,7 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.1
 
-  launch-ide@1.3.1:
+  launch-ide@1.4.0:
     dependencies:
       chalk: 4.1.1
       dotenv: 16.4.5
@@ -38347,7 +38391,7 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  nitropack@2.9.6(@opentelemetry/api@1.9.0)(encoding@0.1.13)(magicast@0.3.4):
+  nitropack@2.9.6(@opentelemetry/api@1.9.0)(encoding@0.1.13)(magicast@0.3.5):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.3
       '@netlify/functions': 2.8.0(@opentelemetry/api@1.9.0)
@@ -38362,7 +38406,7 @@ snapshots:
       '@types/http-proxy': 1.17.14
       '@vercel/nft': 0.26.5(encoding@0.1.13)
       archiver: 7.0.1
-      c12: 1.11.1(magicast@0.3.4)
+      c12: 1.11.1(magicast@0.3.5)
       chalk: 5.3.0
       chokidar: 3.6.0
       citty: 0.1.6
@@ -38716,20 +38760,20 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@24.10.0)(bufferutil@4.0.8)(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.4.1)(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.4)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)):
+  nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@24.10.0)(bufferutil@4.0.8)(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.4.1)(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)):
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 1.3.6(bufferutil@4.0.8)(rollup@4.16.4)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
-      '@nuxt/kit': 3.12.2(magicast@0.3.4)(rollup@4.16.4)
+      '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.16.4)
       '@nuxt/schema': 3.12.2(rollup@4.16.4)
-      '@nuxt/telemetry': 2.5.4(magicast@0.3.4)(rollup@4.16.4)
-      '@nuxt/vite-builder': 3.12.2(@types/node@24.10.0)(eslint@9.39.1(jiti@2.6.1))(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.4)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(vue@3.4.30(typescript@5.9.3))
+      '@nuxt/telemetry': 2.5.4(magicast@0.3.5)(rollup@4.16.4)
+      '@nuxt/vite-builder': 3.12.2(@types/node@24.10.0)(eslint@9.39.1(jiti@2.6.1))(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(vue@3.4.30(typescript@5.9.3))
       '@unhead/dom': 1.9.14
       '@unhead/ssr': 1.9.14
       '@unhead/vue': 1.9.14(vue@3.4.30(typescript@5.9.3))
       '@vue/shared': 3.4.30
       acorn: 8.12.0
-      c12: 1.11.1(magicast@0.3.4)
+      c12: 1.11.1(magicast@0.3.5)
       chokidar: 3.6.0
       cookie-es: 1.1.0
       defu: 6.1.4
@@ -38748,7 +38792,7 @@ snapshots:
       knitwork: 1.1.0
       magic-string: 0.30.10
       mlly: 1.7.1
-      nitropack: 2.9.6(@opentelemetry/api@1.9.0)(encoding@0.1.13)(magicast@0.3.4)
+      nitropack: 2.9.6(@opentelemetry/api@1.9.0)(encoding@0.1.13)(magicast@0.3.5)
       nuxi: 3.12.0
       nypm: 0.3.8
       ofetch: 1.3.4
@@ -44966,7 +45010,7 @@ snapshots:
       stylelint: 14.16.1
       typescript: 5.9.3
 
-  vite-plugin-inspect@0.8.4(@nuxt/kit@3.12.2(magicast@0.3.4)(rollup@4.16.4))(rollup@4.16.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)):
+  vite-plugin-inspect@0.8.4(@nuxt/kit@3.12.2(magicast@0.3.5)(rollup@4.16.4))(rollup@4.16.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)):
     dependencies:
       '@antfu/utils': 0.7.8
       '@rollup/pluginutils': 5.1.0(rollup@4.16.4)
@@ -44979,7 +45023,7 @@ snapshots:
       sirv: 2.0.4
       vite: 5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)
     optionalDependencies:
-      '@nuxt/kit': 3.12.2(magicast@0.3.4)(rollup@4.16.4)
+      '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.16.4)
     transitivePeerDependencies:
       - rollup
       - supports-color


### PR DESCRIPTION
close #410 
- Upgrade launch-ide to 1.4.0
- Add launchType configuration option (exec | open)
- Support faster IDE launching using open method on MacOS
- Update documentation for both English and Chinese
- Add TypeScript type definitions for launchType