### PR TITLE
fix(webpack-loader): fix $ symbol escape issue when replacing script content

### DIFF
--- a/packages/webpack/src/loader.ts
+++ b/packages/webpack/src/loader.ts
@@ -60,7 +60,7 @@ export default async function WebpackCodeInspectorLoader(content: string) {
         escapeTags,
         pathType: options.pathType,
       });
-      content = content.replace(script, newScript);
+      content = content.replace(script, () => newScript);
     }
     return content;
   }


### PR DESCRIPTION
## 🔧 Fix: 修复 loader 中 $$ 符号被错误转义导致的标识符改写问题

### 问题背景
当前插件在 webpack loader 中替换 script 内容时，因 String.replace 特性导致 `.vue` 文件中 `<script lang="tsx/jsx">` 里的 `$$t` 标识符被错误改写为 `$t`，引发运行时导出不存在的报错（如 `export '$t' was not found in '@/locales'`）。
该问题影响所有版本（当前验证 1.4.0 存在，推测全版本受影响），与 transformCode 逻辑无关，仅出现在脚本内容回填的字符串替换环节。

### 问题根因
loader 中使用 `content.replace(script, newScript)` 进行内容替换时，JS 原生 String.replace 会将替换字符串中的 `$$` 解析为单个 `$`，导致 `$$t` 被改写为 `$t`。

### 修复方案
将字符串替换方式从直接传替换值改为传入函数回调，规避 String.replace 对 `$` 符号的特殊解析：
```javascript
// 原代码
content = content.replace(script, newScript)

// 修复后
content = content.replace(script, () => newScript)