### PR TITLE
fix(ai): repair multimodal image handling for codex cli/sdk

### DIFF
--- a/packages/core/src/client/ai.ts
+++ b/packages/core/src/client/ai.ts
@@ -56,8 +56,15 @@ export interface ContentBlock {
 export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
+  modelContent?: string;
   blocks?: ContentBlock[];
   context?: ChatContext | null;
+  images?: ChatImageAttachment[];
+}
+
+export interface ChatHistoryMessage {
+  role: 'user' | 'assistant';
+  content: string;
 }
 
 /**
@@ -70,6 +77,14 @@ export interface ChatContext {
   name: string;
 }
 
+export interface ChatImageAttachment {
+  id: string;
+  name: string;
+  type: string;
+  size: number;
+  previewUrl: string;
+}
+
 /**
  * 聊天状态接口
  */
@@ -78,6 +93,8 @@ export interface ChatState {
   showCloseConfirm: boolean;
   chatMessages: ChatMessage[];
   chatInput: string;
+  chatPastedImages: ChatImageAttachment[];
+  chatImageProcessing: boolean;
   chatLoading: boolean;
   chatContext: ChatContext | null;
   currentTools: Map<string, ToolCall>;
@@ -99,6 +116,8 @@ export interface ChatHandlers {
   clearChatMessages: () => void;
   handleChatInput: (e: Event) => void;
   handleChatKeyDown: (e: KeyboardEvent) => void;
+  handleChatPaste: (e: ClipboardEvent) => void;
+  removePastedImage: (id: string) => void;
   sendChatMessage: () => void;
   toggleTheme: () => void;
   interruptChat: () => void;
@@ -605,6 +624,20 @@ function renderMessageContent(msg: ChatMessage): TemplateResult {
     `;
   }
 
+  if (msg.role === 'user' && Array.isArray(msg.images) && msg.images.length > 0) {
+    return html`
+      <div class="chat-image-grid">
+        ${msg.images.map((image) => html`
+          <div class="chat-image-item">
+            <img class="chat-image-preview" src="${image.previewUrl}" alt="${image.name || 'pasted-image'}" />
+            <div class="chat-image-meta">${image.name || 'pasted-image'}</div>
+          </div>
+        `)}
+      </div>
+      ${msg.content ? html`<div class="chat-text-inline">${msg.content}</div>` : ''}
+    `;
+  }
+
   // 否则只渲染文本内容
   if (isAssistant && msg.content) {
     return html`<div class="chat-text-inline chat-markdown">${unsafeHTML(renderMarkdown(msg.content))}</div>`;
@@ -769,23 +802,41 @@ export function renderChatModal(
             </div>`
       : ''}
         <div class="chat-modal-footer">
+          ${state.chatPastedImages.length > 0
+      ? html`<div class="chat-paste-preview">
+                ${state.chatPastedImages.map((image) => html`
+                  <div class="chat-paste-preview-item">
+                    <img class="chat-paste-preview-img" src="${image.previewUrl}" alt="${image.name || 'pasted-image'}" />
+                    <button
+                      class="chat-paste-remove"
+                      title="Remove image"
+                      @click="${() => handlers.removePastedImage(image.id)}"
+                      ?disabled="${state.chatLoading || state.chatImageProcessing}"
+                    >
+                      ×
+                    </button>
+                  </div>
+                `)}
+              </div>`
+      : ''}
           <span class="chat-input-prompt">❯</span>
           <textarea
             class="chat-input"
-            placeholder="Enter your message..."
+            placeholder="Enter your message... (supports paste image)"
             .value="${state.chatInput}"
             @input="${handlers.handleChatInput}"
             @keydown="${handlers.handleChatKeyDown}"
-            ?disabled="${state.chatLoading}"
+            @paste="${handlers.handleChatPaste}"
+            ?disabled="${state.chatLoading || state.chatImageProcessing}"
             rows="2"
           ></textarea>
           <button
             class="chat-send-btn"
             @click="${handlers.sendChatMessage}"
-            ?disabled="${state.chatLoading || !state.chatInput.trim()}"
+            ?disabled="${state.chatLoading || state.chatImageProcessing || (!state.chatInput.trim() && state.chatPastedImages.length === 0)}"
             title="Send (Enter)"
           >
-            ${state.chatLoading
+            ${state.chatLoading || state.chatImageProcessing
       ? html`<svg
                   class="chat-send-loading"
                   width="16"
@@ -1294,6 +1345,36 @@ export const chatStyles = css`
     white-space: nowrap;
   }
 
+  .chat-image-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 8px;
+    margin-bottom: 2px;
+  }
+
+  .chat-image-item {
+    border: 1px solid var(--chat-border);
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--chat-tool-bg);
+  }
+
+  .chat-image-preview {
+    width: 100%;
+    height: 84px;
+    object-fit: cover;
+    display: block;
+  }
+
+  .chat-image-meta {
+    padding: 4px 6px;
+    font-size: 10px;
+    color: var(--chat-text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .chat-text-inline {
     white-space: pre-wrap;
     word-break: break-word;
@@ -1542,6 +1623,54 @@ export const chatStyles = css`
     padding: 10px 14px;
     border-top: 1px solid var(--chat-border);
     background: var(--chat-header-bg);
+    flex-wrap: wrap;
+  }
+
+  .chat-paste-preview {
+    width: 100%;
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  .chat-paste-preview-item {
+    position: relative;
+    flex: 0 0 auto;
+    width: 56px;
+    height: 56px;
+    border-radius: 6px;
+    overflow: hidden;
+    border: 1px solid var(--chat-border);
+    background: var(--chat-tool-bg);
+  }
+
+  .chat-paste-preview-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .chat-paste-remove {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 16px;
+    height: 16px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.65);
+    color: #fff;
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 16px;
+    padding: 0;
+  }
+
+  .chat-paste-remove:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 
   .chat-input-prompt {
@@ -1793,7 +1922,7 @@ export async function sendChatToServer(
   port: number,
   message: string,
   context: ChatContext | null,
-  history: ChatMessage[],
+  history: ChatHistoryMessage[],
   handlers: StreamHandlers,
   signal?: AbortSignal,
   sessionId?: string | null

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -7,6 +7,8 @@ import { browserChalk } from '../shared/browser-chalk';
 import {
   ChatMessage,
   ChatContext,
+  ChatImageAttachment,
+  ChatHistoryMessage,
   ContentBlock,
   ToolCall,
   renderChatModal,
@@ -79,6 +81,10 @@ interface ActiveNode {
   content?: string;
   visibility?: 'visible' | 'hidden';
   class?: 'tooltip-top' | 'tooltip-bottom';
+}
+
+interface PendingChatImageAttachment extends ChatImageAttachment {
+  dataUrl: string;
 }
 
 const PopperWidth = 300;
@@ -197,6 +203,10 @@ export class CodeInspectorComponent extends LitElement {
   chatMessages: ChatMessage[] = []; // 聊天消息列表
   @state()
   chatInput = ''; // 聊天输入内容
+  @state()
+  chatPastedImages: PendingChatImageAttachment[] = []; // 输入框待发送图片
+  @state()
+  chatImageProcessing = false; // 粘贴图片处理中
   @state()
   chatLoading = false; // 聊天加载状态
   @state()
@@ -1210,6 +1220,7 @@ export class CodeInspectorComponent extends LitElement {
 
   // 持久化 AI 对话状态到 sessionStorage
   private persistAIState = () => {
+    const persistedMessages: ChatMessage[] = this.chatMessages.map(({ modelContent, ...rest }) => rest);
     let modalPosition: { left: string; top: string } | null = null;
     if (this.showChatModal) {
       const chatModal = this.shadowRoot?.querySelector('#chat-modal-floating') as HTMLElement;
@@ -1219,7 +1230,7 @@ export class CodeInspectorComponent extends LitElement {
     }
     saveAIState({
       showChatModal: this.showChatModal,
-      chatMessages: this.chatMessages,
+      chatMessages: persistedMessages,
       chatContext: this.chatContext,
       chatSessionId: this.chatSessionId,
       chatTheme: this.chatTheme,
@@ -1227,6 +1238,71 @@ export class CodeInspectorComponent extends LitElement {
       modalPosition,
       turnStatus: this.turnStatus,
     });
+  };
+
+  private revokeObjectUrl = (url?: string) => {
+    if (url && url.startsWith('blob:')) {
+      URL.revokeObjectURL(url);
+    }
+  };
+
+  private revokeMessageImageUrls = (messages: ChatMessage[]) => {
+    for (const msg of messages) {
+      if (!Array.isArray(msg.images)) continue;
+      for (const image of msg.images) {
+        this.revokeObjectUrl(image.previewUrl);
+      }
+    }
+  };
+
+  private clearPendingPastedImages = (revoke = true) => {
+    if (revoke) {
+      for (const image of this.chatPastedImages) {
+        this.revokeObjectUrl(image.previewUrl);
+      }
+    }
+    this.chatPastedImages = [];
+    this.chatImageProcessing = false;
+  };
+
+  private readFileAsDataUrl = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result || ''));
+      reader.onerror = () => reject(new Error('Failed to read image'));
+      reader.readAsDataURL(file);
+    });
+  };
+
+  private formatBytes = (bytes: number): string => {
+    if (bytes < 1024) return `${bytes}B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  };
+
+  private buildMessageWithPastedImages = (message: string, images: PendingChatImageAttachment[]): string => {
+    if (images.length === 0) {
+      return message;
+    }
+
+    const imageBlocks = images.map((image, index) => {
+      const name = image.name || `pasted-image-${index + 1}`;
+      const type = image.type || 'image';
+      return `[Pasted Image ${index + 1}] ${name} (${type}, ${this.formatBytes(image.size)})\n${image.dataUrl}`;
+    });
+
+    const baseMessage = message.trim();
+    if (!baseMessage) {
+      return imageBlocks.join('\n\n');
+    }
+    return `${baseMessage}\n\n${imageBlocks.join('\n\n')}`;
+  };
+
+  private buildChatHistoryForModel = (messages: ChatMessage[]): ChatHistoryMessage[] => {
+    return messages.map((msg) => ({
+      role: msg.role,
+      content: msg.modelContent || msg.content,
+    }));
   };
 
   // 打开聊天框
@@ -1298,6 +1374,8 @@ export class CodeInspectorComponent extends LitElement {
 
     // 恢复背景滚动
     document.body.style.overflow = '';
+    // 关闭时清理未发送的粘贴图片
+    this.clearPendingPastedImages(true);
 
     // 关闭弹窗时清除持久化状态
     clearAIState();
@@ -1334,6 +1412,8 @@ export class CodeInspectorComponent extends LitElement {
 
   // 清空聊天记录
   clearChatMessages = () => {
+    this.revokeMessageImageUrls(this.chatMessages);
+    this.clearPendingPastedImages(true);
     this.chatMessages = [];
     this.chatSessionId = null;
     this.turnStatus = 'idle';
@@ -1363,6 +1443,57 @@ export class CodeInspectorComponent extends LitElement {
       e.preventDefault();
       this.sendChatMessage();
     }
+  };
+
+  handleChatPaste = async (e: ClipboardEvent) => {
+    const items = Array.from(e.clipboardData?.items || []);
+    const imageItems = items.filter((item) => item.type.startsWith('image/'));
+    if (imageItems.length === 0) {
+      return;
+    }
+
+    e.preventDefault();
+    this.chatImageProcessing = true;
+
+    const maxImageSize = 5 * 1024 * 1024; // 5MB per image
+    const addedImages: PendingChatImageAttachment[] = [];
+
+    for (let i = 0; i < imageItems.length; i++) {
+      const file = imageItems[i].getAsFile();
+      if (!file) continue;
+
+      if (file.size > maxImageSize) {
+        this.showNotification(`Image too large (${this.formatBytes(file.size)}). Max 5MB.`, 'error');
+        continue;
+      }
+
+      try {
+        const dataUrl = await this.readFileAsDataUrl(file);
+        const previewUrl = URL.createObjectURL(file);
+        const id = `${Date.now()}-${Math.random().toString(16).slice(2)}-${i}`;
+        addedImages.push({
+          id,
+          name: file.name || `pasted-image-${i + 1}.png`,
+          type: file.type || 'image/png',
+          size: file.size,
+          previewUrl,
+          dataUrl,
+        });
+      } catch {
+        this.showNotification('Failed to read pasted image', 'error');
+      }
+    }
+
+    this.chatPastedImages = [...this.chatPastedImages, ...addedImages];
+    this.chatImageProcessing = false;
+  };
+
+  removePastedImage = (id: string) => {
+    const target = this.chatPastedImages.find((item) => item.id === id);
+    if (target) {
+      this.revokeObjectUrl(target.previewUrl);
+    }
+    this.chatPastedImages = this.chatPastedImages.filter((item) => item.id !== id);
   };
 
   // 滚动聊天内容到底部（去重，避免高频调用）
@@ -1477,16 +1608,30 @@ export class CodeInspectorComponent extends LitElement {
 
   // 发送聊天消息
   sendChatMessage = async () => {
-    if (!this.chatInput.trim() || this.chatLoading) return;
+    if (this.chatLoading || this.chatImageProcessing) return;
 
-    const userMessage = this.chatInput.trim();
+    const historyForRequest = this.buildChatHistoryForModel(this.chatMessages);
+    const rawMessage = this.chatInput.trim();
+    const pendingImages = this.chatPastedImages;
+    if (!rawMessage && pendingImages.length === 0) return;
+
+    const outgoingMessage = this.buildMessageWithPastedImages(rawMessage, pendingImages);
+    const userMessage = rawMessage || `[Pasted ${pendingImages.length} image${pendingImages.length > 1 ? 's' : ''}]`;
+    const userImages: ChatImageAttachment[] = pendingImages.map((image) => ({
+      id: image.id,
+      name: image.name,
+      type: image.type,
+      size: image.size,
+      previewUrl: image.previewUrl,
+    }));
     const messageContext = this.chatContext
       ? { ...this.chatContext }
       : null;
     this.chatInput = '';
+    this.chatPastedImages = [];
     this.chatMessages = [
       ...this.chatMessages,
-      { role: 'user', content: userMessage, context: messageContext },
+      { role: 'user', content: userMessage, modelContent: outgoingMessage, context: messageContext, images: userImages },
     ];
     this.chatLoading = true;
     this.scrollChatToBottom();
@@ -1536,9 +1681,9 @@ export class CodeInspectorComponent extends LitElement {
       await sendChatToServer(
         this.ip,
         this.port,
-        userMessage,
+        outgoingMessage,
         this.chatContext,
-        this.chatMessages.slice(0, -1), // 不包含空的 assistant 消息
+        historyForRequest,
         {
           onText: (content) => {
             assistantContent += content;
@@ -1644,6 +1789,7 @@ export class CodeInspectorComponent extends LitElement {
   private resumeAITask = async () => {
     if (!this.chatSessionId || this.chatLoading) return;
 
+    const historyForRequest = this.buildChatHistoryForModel(this.chatMessages);
     this.chatLoading = true;
     this.startTurnTimer();
     this.chatAbortController = new AbortController();
@@ -1687,7 +1833,7 @@ export class CodeInspectorComponent extends LitElement {
         this.port,
         'The previous task was interrupted by a page refresh. Please continue from where you left off.',
         this.chatContext,
-        this.chatMessages.slice(0, -1),
+        historyForRequest,
         {
           onText: (content) => {
             assistantContent += content;
@@ -1915,8 +2061,11 @@ export class CodeInspectorComponent extends LitElement {
   }
 
   disconnectedCallback(): void {
+    this.revokeMessageImageUrls(this.chatMessages);
+    this.clearPendingPastedImages(true);
     // Detach all event listeners
     this.detachEventListeners();
+    super.disconnectedCallback();
   }
 
   renderNodeTree = (node: TreeNode): TemplateResult => html`
@@ -2212,6 +2361,8 @@ export class CodeInspectorComponent extends LitElement {
             showCloseConfirm: this.showCloseConfirm,
             chatMessages: this.chatMessages,
             chatInput: this.chatInput,
+            chatPastedImages: this.chatPastedImages,
+            chatImageProcessing: this.chatImageProcessing,
             chatLoading: this.chatLoading,
             chatContext: this.chatContext,
             currentTools: this.currentTools,
@@ -2229,6 +2380,8 @@ export class CodeInspectorComponent extends LitElement {
             clearChatMessages: this.clearChatMessages,
             handleChatInput: this.handleChatInput,
             handleChatKeyDown: this.handleChatKeyDown,
+            handleChatPaste: this.handleChatPaste,
+            removePastedImage: this.removePastedImage,
             sendChatMessage: this.sendChatMessage,
             toggleTheme: this.toggleTheme,
             interruptChat: this.interruptChat,

--- a/packages/core/src/server/ai-provider-claude.ts
+++ b/packages/core/src/server/ai-provider-claude.ts
@@ -27,6 +27,68 @@ export interface ProviderResult {
   abort: () => void;
 }
 
+interface InlineImagePayload {
+  mediaType: string;
+  data: string;
+}
+
+interface ClaudeCliInputMessage {
+  type: 'user';
+  session_id: string;
+  parent_tool_use_id: null;
+  message: {
+    role: 'user';
+    content: Array<
+      | { type: 'text'; text: string }
+      | { type: 'image'; source: { type: 'base64'; media_type: string; data: string } }
+    >;
+  };
+}
+
+const INLINE_IMAGE_DATA_URL_REGEX = /data:(image\/[a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=]+)/g;
+
+function stripInlineImageDataUrls(text: string): string {
+  return text.replace(INLINE_IMAGE_DATA_URL_REGEX, '[Inline image data omitted]');
+}
+
+function extractInlineImages(text: string): { text: string; images: InlineImagePayload[] } {
+  const images: InlineImagePayload[] = [];
+  let imageIndex = 0;
+  const rewritten = text.replace(INLINE_IMAGE_DATA_URL_REGEX, (_match, mediaType: string, data: string) => {
+    imageIndex += 1;
+    images.push({ mediaType, data });
+    return `[Inline image ${imageIndex} attached separately (${mediaType})]`;
+  });
+
+  return { text: rewritten, images };
+}
+
+function buildClaudeCliInputMessage(
+  promptText: string,
+  images: InlineImagePayload[],
+  sessionId?: string
+): ClaudeCliInputMessage {
+  return {
+    type: 'user',
+    session_id: sessionId || '',
+    parent_tool_use_id: null,
+    message: {
+      role: 'user',
+      content: [
+        { type: 'text', text: promptText },
+        ...images.map((image) => ({
+          type: 'image' as const,
+          source: {
+            type: 'base64' as const,
+            media_type: image.mediaType,
+            data: image.data,
+          },
+        })),
+      ],
+    },
+  };
+}
+
 /**
  * 构建完整的提示信息
  */
@@ -61,6 +123,20 @@ function buildPrompt(
   parts.push(`[Current question] ${message}`);
 
   return parts.join('\n\n');
+}
+
+/**
+ * 构建续会话单轮提示：
+ * - 保留当前轮 context，避免模型长期锚定首轮 context
+ * - 不重复拼接历史（由 session/resume 自身维护）
+ */
+function buildResumeTurnPrompt(
+  message: string,
+  context: AIContext | null,
+  projectRootPath: string
+): string {
+  return buildPrompt(message, context, [], projectRootPath) +
+    '\n\n[Note] Context above applies to this turn only. Prior turn context may be outdated.';
 }
 
 /**
@@ -187,15 +263,32 @@ export function handleClaudeRequest(
 
   if (agentType === 'cli' && cliPath) {
     // 使用本地 CLI
-    // 有 sessionId 时使用 --resume 恢复会话，prompt 只需当前消息
+    // 有 sessionId 时使用 --resume 恢复会话，同时注入本轮 context，避免首轮 context 锚定
     // 无 sessionId 时为首次对话，构建包含 context 的完整 prompt
-    const prompt = sessionId ? message : buildPrompt(message, context, history, cwd);
+    const cliHistory: AIMessage[] = history.map((msg) => ({
+      role: msg.role,
+      content: stripInlineImageDataUrls(msg.content),
+    }));
+    const extracted = extractInlineImages(message);
+    const prompt = sessionId
+      ? buildResumeTurnPrompt(extracted.text, context, cwd)
+      : buildPrompt(extracted.text, context, cliHistory, cwd);
+    const cliInputMessage = extracted.images.length > 0
+      ? buildClaudeCliInputMessage(prompt, extracted.images, sessionId)
+      : undefined;
 
     sendSSE({ type: 'info', message: 'Using local Claude Code CLI', cwd, model });
+    if (extracted.images.length > 0) {
+      sendSSE({
+        type: 'info',
+        message: `Detected ${extracted.images.length} image(s). Sending via Claude CLI stream-json input.`,
+      });
+    }
 
     childProcess = queryViaCli(
       cliPath,
       prompt,
+      cliInputMessage,
       cwd,
       aiOptions,
       (jsonData) => {
@@ -224,10 +317,61 @@ export function handleClaudeRequest(
       try {
         sendSSE({ type: 'info', message: 'Using Claude Agent SDK', cwd, model });
 
-        const sdkPrompt = sessionId ? message : buildPrompt(message, context, history, cwd);
+        const sdkHistory: AIMessage[] = history.map((msg) => ({
+          role: msg.role,
+          content: stripInlineImageDataUrls(msg.content),
+        }));
+        const extracted = extractInlineImages(message);
+        const sdkPromptText = sessionId
+          ? buildResumeTurnPrompt(extracted.text, context, cwd)
+          : buildPrompt(extracted.text, context, sdkHistory, cwd);
+        const sdkPromptInput: string | AsyncIterable<any> = extracted.images.length > 0
+          ? {
+              [Symbol.asyncIterator]() {
+                let emitted = false;
+                return {
+                  next: async () => {
+                    if (emitted) {
+                      return { value: undefined, done: true };
+                    }
+                    emitted = true;
+                    return {
+                      value: {
+                        type: 'user',
+                        session_id: sessionId || '',
+                        parent_tool_use_id: null,
+                        message: {
+                          role: 'user',
+                          content: [
+                            { type: 'text', text: sdkPromptText },
+                            ...extracted.images.map((image) => ({
+                              type: 'image',
+                              source: {
+                                type: 'base64',
+                                media_type: image.mediaType,
+                                data: image.data,
+                              },
+                            })),
+                          ],
+                        },
+                      },
+                      done: false,
+                    };
+                  },
+                };
+              },
+            }
+          : sdkPromptText;
+
+        if (extracted.images.length > 0) {
+          sendSSE({
+            type: 'info',
+            message: `Detected ${extracted.images.length} image(s). Sending as multimodal input.`,
+          });
+        }
 
         const sdkRunState = await queryViaSdk(
-          sdkPrompt,
+          sdkPromptInput,
           cwd,
           aiOptions,
           sessionId,
@@ -240,9 +384,27 @@ export function handleClaudeRequest(
             type: 'info',
             message: 'Claude SDK timed out without response. Falling back to local Claude CLI.',
           });
+          const fallbackHistory: AIMessage[] = history.map((msg) => ({
+            role: msg.role,
+            content: stripInlineImageDataUrls(msg.content),
+          }));
+          const fallbackExtracted = extractInlineImages(message);
+          const fallbackPrompt = sessionId
+            ? buildResumeTurnPrompt(fallbackExtracted.text, context, cwd)
+            : buildPrompt(fallbackExtracted.text, context, fallbackHistory, cwd);
+          const fallbackCliInputMessage = fallbackExtracted.images.length > 0
+            ? buildClaudeCliInputMessage(fallbackPrompt, fallbackExtracted.images, sessionId)
+            : undefined;
+          if (fallbackExtracted.images.length > 0) {
+            sendSSE({
+              type: 'info',
+              message: `Detected ${fallbackExtracted.images.length} image(s). Sending via Claude CLI stream-json input.`,
+            });
+          }
           childProcess = queryViaCli(
             cliPath,
-            sdkPrompt,
+            fallbackPrompt,
+            fallbackCliInputMessage,
             cwd,
             aiOptions,
             (jsonData) => {
@@ -343,6 +505,7 @@ function findClaudeCodeCli(): string | null {
 function queryViaCli(
   cliPath: string,
   prompt: string,
+  inputMessage: ClaudeCliInputMessage | undefined,
   cwd: string,
   aiOptions: ClaudeCodeOptions | undefined,
   onData: (data: string) => void,
@@ -352,12 +515,20 @@ function queryViaCli(
   onSessionId?: (id: string) => void
 ): ChildProcess {
   const opts = getClaudeCliOptions(aiOptions);
-  const args = [
-    '-p', prompt,
-    '--output-format', 'stream-json',
-    '--verbose',
-    '--permission-mode', opts?.permissionMode || 'bypassPermissions',
-  ];
+  const args = inputMessage
+    ? [
+        '-p',
+        '--output-format', 'stream-json',
+        '--input-format', 'stream-json',
+        '--verbose',
+        '--permission-mode', opts?.permissionMode || 'bypassPermissions',
+      ]
+    : [
+        '-p', prompt,
+        '--output-format', 'stream-json',
+        '--verbose',
+        '--permission-mode', opts?.permissionMode || 'bypassPermissions',
+      ];
 
   if (sessionId) {
     args.push('--resume', sessionId);
@@ -402,6 +573,9 @@ function queryViaCli(
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
+  if (inputMessage) {
+    child.stdin?.write(`${JSON.stringify(inputMessage)}\n`);
+  }
   child.stdin?.end();
 
   let buffer = '';
@@ -640,7 +814,7 @@ function buildSdkQueryOptions(
 }
 
 async function queryViaSdk(
-  prompt: string,
+  prompt: string | AsyncIterable<any>,
   cwd: string,
   aiOptions: ClaudeCodeOptions | undefined,
   sessionId: string | undefined,

--- a/packages/core/src/server/ai-provider-codex.ts
+++ b/packages/core/src/server/ai-provider-codex.ts
@@ -48,6 +48,112 @@ function buildPrompt(
 }
 
 /**
+ * 构建续会话单轮提示：
+ * - 保留当前轮 context，避免模型长期锚定首轮 context
+ * - 不重复拼接历史（由 session/resume 自身维护）
+ */
+function buildResumeTurnPrompt(
+  message: string,
+  context: AIContext | null,
+  projectRootPath: string
+): string {
+  return buildPrompt(message, context, [], projectRootPath) +
+    '\n\n[Note] Context above applies to this turn only. Prior turn context may be outdated.';
+}
+
+interface InlineImagePayload {
+  mediaType: string;
+  data: string;
+}
+
+type TempImageWriteResult = {
+  imagePaths: string[];
+  failedCount: number;
+};
+
+type CodexRunInputItem =
+  | { type: 'text'; text: string }
+  | { type: 'local_image'; path: string };
+
+const INLINE_IMAGE_DATA_URL_REGEX = /data:(image\/[a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=]+)/g;
+
+function stripInlineImageDataUrls(text: string): string {
+  return text.replace(INLINE_IMAGE_DATA_URL_REGEX, '[Inline image data omitted]');
+}
+
+function extractInlineImages(text: string): { text: string; images: InlineImagePayload[] } {
+  const images: InlineImagePayload[] = [];
+  let imageIndex = 0;
+  const rewritten = text.replace(INLINE_IMAGE_DATA_URL_REGEX, (_match, mediaType: string, data: string) => {
+    imageIndex += 1;
+    images.push({ mediaType, data });
+    return `[Inline image ${imageIndex} attached separately (${mediaType})]`;
+  });
+
+  return { text: rewritten, images };
+}
+
+function mediaTypeToExtension(mediaType: string): string {
+  const normalized = mediaType.toLowerCase();
+  if (normalized === 'image/jpeg') return 'jpg';
+  if (normalized === 'image/svg+xml') return 'svg';
+  if (normalized === 'image/x-icon') return 'ico';
+  const subtype = normalized.split('/')[1] || 'png';
+  return subtype.split('+')[0] || 'png';
+}
+
+function persistInlineImagesToTempFiles(images: InlineImagePayload[]): TempImageWriteResult {
+  const imagePaths: string[] = [];
+  let failedCount = 0;
+
+  for (const image of images) {
+    try {
+      const ext = mediaTypeToExtension(image.mediaType);
+      const filename = `code-inspector-codex-image-${Date.now()}-${Math.random().toString(16).slice(2)}.${ext}`;
+      const filePath = path.join(os.tmpdir(), filename);
+      const bytes = Buffer.from(image.data, 'base64');
+      fs.writeFileSync(filePath, bytes);
+      imagePaths.push(filePath);
+    } catch {
+      failedCount += 1;
+    }
+  }
+
+  return { imagePaths, failedCount };
+}
+
+function cleanupTempFiles(filePaths: string[]): void {
+  for (const filePath of filePaths) {
+    try {
+      if (filePath && fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
+
+function buildCodexSdkRunInput(promptText: string, imagePaths: string[]): string | CodexRunInputItem[] {
+  if (imagePaths.length === 0) {
+    return promptText;
+  }
+  return [
+    { type: 'text', text: promptText },
+    ...imagePaths.map((filePath) => ({ type: 'local_image' as const, path: filePath })),
+  ];
+}
+
+export const __TEST_ONLY__ = {
+  stripInlineImageDataUrls,
+  extractInlineImages,
+  persistInlineImagesToTempFiles,
+  cleanupTempFiles,
+  buildCodexSdkRunInput,
+  buildCodexExecArgs,
+};
+
+/**
  * 缓存 CLI 检测到的模型名
  */
 let cachedCliModel: string | undefined;
@@ -108,7 +214,7 @@ export function handleCodexRequest(
   const { sendSSE, onEnd } = callbacks;
   const agentType = codexOptions?.agent || 'cli';
   const options = getCodexAgentOptions(codexOptions);
-  const cliPath = agentType === 'cli' ? findCodexCli() : null;
+  const cliPath = findCodexCli();
   const model = options.model || '';
 
   let childProcess: ChildProcess | null = null;
@@ -116,19 +222,40 @@ export function handleCodexRequest(
   let aborted = false;
 
   if (agentType === 'cli' && cliPath) {
-    // 有 sessionId 时使用 resume 恢复会话，prompt 只需当前消息
+    // 有 sessionId 时使用 resume 恢复会话，同时注入本轮 context，避免首轮 context 锚定
     // 无 sessionId 时为首次对话，构建包含 context 的完整 prompt
-    const prompt = sessionId ? message : buildPrompt(message, context, history, cwd);
+    const cliHistory: AIMessage[] = history.map((msg) => ({
+      role: msg.role,
+      content: stripInlineImageDataUrls(msg.content),
+    }));
+    const extracted = extractInlineImages(message);
+    const prompt = sessionId
+      ? buildResumeTurnPrompt(extracted.text, context, cwd)
+      : buildPrompt(extracted.text, context, cliHistory, cwd);
 
     sendSSE({ type: 'info', message: 'Using local Codex CLI', cwd, model });
 
     const cliOptions = getCodexCliOptions(codexOptions);
+    const cliImageFiles = persistInlineImagesToTempFiles(extracted.images);
+    if (cliImageFiles.imagePaths.length > 0) {
+      sendSSE({
+        type: 'info',
+        message: `Detected ${cliImageFiles.imagePaths.length} image(s). Sending via Codex CLI --image.`,
+      });
+    }
+    if (cliImageFiles.failedCount > 0) {
+      sendSSE({
+        type: 'info',
+        message: `Failed to process ${cliImageFiles.failedCount} inline image(s).`,
+      });
+    }
 
     childProcess = queryViaCli(
       cliPath,
       prompt,
       cwd,
       cliOptions,
+      cliImageFiles.imagePaths,
       (jsonData) => {
         try {
           const data = JSON.parse(jsonData);
@@ -158,31 +285,134 @@ export function handleCodexRequest(
   } else {
     // 使用 SDK（agent='sdk' 或 agent='cli' 但 CLI 未找到时回退）
     (async () => {
+      const sdkHistory: AIMessage[] = history.map((msg) => ({
+        role: msg.role,
+        content: stripInlineImageDataUrls(msg.content),
+      }));
+      const extracted = extractInlineImages(message);
+      const sdkPrompt = sessionId
+        ? buildResumeTurnPrompt(extracted.text, context, cwd)
+        : buildPrompt(extracted.text, context, sdkHistory, cwd);
+      const sdkOptions = getCodexSdkOptions(codexOptions);
+      const sdkImageFiles = persistInlineImagesToTempFiles(extracted.images);
+      const sdkInput = buildCodexSdkRunInput(sdkPrompt, sdkImageFiles.imagePaths);
+
+      if (sdkImageFiles.imagePaths.length > 0) {
+        sendSSE({
+          type: 'info',
+          message: `Detected ${sdkImageFiles.imagePaths.length} image(s). Sending as Codex SDK multimodal input.`,
+        });
+      }
+      if (sdkImageFiles.failedCount > 0) {
+        sendSSE({
+          type: 'info',
+          message: `Failed to process ${sdkImageFiles.failedCount} inline image(s).`,
+        });
+      }
+
       try {
         if (agentType === 'cli' && !cliPath) {
           sendSSE({ type: 'info', message: 'Codex CLI not found. Falling back to Codex SDK', cwd });
         }
         sendSSE({ type: 'info', message: 'Using Codex SDK', cwd, model });
 
-        const sdkPrompt = sessionId ? message : buildPrompt(message, context, history, cwd);
-        const sdkOptions = getCodexSdkOptions(codexOptions);
-
         activeThread = await queryViaSdk(
-          sdkPrompt,
+          sdkInput,
           cwd,
           sdkOptions,
           sessionId,
           sendSSE,
-          () => aborted
+          () => aborted,
+          sdkImageFiles.imagePaths
         );
 
         sendSSE('[DONE]');
         onEnd();
       } catch (error: any) {
-        if (!aborted) {
-          console.log(chalk.red('[code-inspector-plugin] Codex AI error:') + error.message);
+        let finalError = error;
+        if (!aborted && extracted.images.length > 0 && cliPath) {
           sendSSE({
-            error: `Failed to communicate with Codex: ${error.message}. Install Codex CLI or configure Codex SDK.`,
+            type: 'info',
+            message: `Codex SDK image input failed. Falling back to local Codex CLI. (${error.message})`,
+          });
+          const cliOptions = getCodexCliOptions(codexOptions);
+          const fallbackImageFiles = persistInlineImagesToTempFiles(extracted.images);
+          if (fallbackImageFiles.imagePaths.length > 0) {
+            sendSSE({
+              type: 'info',
+              message: `Detected ${fallbackImageFiles.imagePaths.length} image(s). Sending via Codex CLI --image.`,
+            });
+          }
+          if (fallbackImageFiles.failedCount > 0) {
+            sendSSE({
+              type: 'info',
+              message: `Failed to process ${fallbackImageFiles.failedCount} inline image(s).`,
+            });
+          }
+          childProcess = queryViaCli(
+            cliPath,
+            sdkPrompt,
+            cwd,
+            cliOptions,
+            fallbackImageFiles.imagePaths,
+            (jsonData) => {
+              try {
+                const data = JSON.parse(jsonData);
+                sendSSE(data);
+              } catch {
+                sendSSE({ type: 'text', content: jsonData });
+              }
+            },
+            (sdkFallbackError) => {
+              sendSSE({ error: sdkFallbackError });
+            },
+            () => {
+              sendSSE('[DONE]');
+              onEnd();
+            },
+            sessionId,
+            (newSessionId) => {
+              sendSSE({ type: 'session', sessionId: newSessionId });
+            },
+            (newModel) => {
+              if (newModel) {
+                sendSSE({ type: 'info', model: newModel });
+              }
+            },
+            () => aborted
+          );
+          return;
+        }
+        if (!aborted && extracted.images.length > 0 && !cliPath) {
+          sendSSE({
+            type: 'info',
+            message:
+              `Codex SDK image input failed and local Codex CLI is unavailable. ` +
+              `Retrying with text-only prompt. (${error.message})`,
+          });
+          try {
+            activeThread = await queryViaSdk(
+              sdkPrompt,
+              cwd,
+              sdkOptions,
+              sessionId,
+              sendSSE,
+              () => aborted,
+              []
+            );
+            sendSSE('[DONE]');
+            onEnd();
+            return;
+          } catch (retryError: any) {
+            finalError = retryError;
+          }
+        }
+        if (!aborted) {
+          console.log(chalk.red('[code-inspector-plugin] Codex AI error:') + finalError.message);
+          sendSSE({
+            error:
+              `Failed to communicate with Codex: ${finalError.message}. ` +
+              'Install Codex CLI or configure Codex SDK.',
           });
           sendSSE('[DONE]');
           onEnd();
@@ -292,6 +522,23 @@ function buildCommonArgs(
   return args;
 }
 
+function buildCodexExecArgs(
+  codexOptions: CodexCliOptions,
+  outputFile: string,
+  imagePaths: string[],
+  prompt: string,
+  sessionId?: string
+): string[] {
+  const commonArgs = buildCommonArgs(codexOptions, outputFile);
+  const imageArgs = imagePaths.flatMap((filePath) => ['--image', filePath]);
+  const separatorArgs = imageArgs.length > 0 ? ['--'] : [];
+
+  if (sessionId) {
+    return ['exec', 'resume', ...commonArgs, ...imageArgs, ...separatorArgs, sessionId, prompt];
+  }
+  return ['exec', ...commonArgs, ...imageArgs, ...separatorArgs, prompt];
+}
+
 function extractTextFromContent(content: any): string {
   if (!content) return '';
   if (typeof content === 'string') return content;
@@ -370,6 +617,7 @@ function queryViaCli(
   prompt: string,
   cwd: string,
   codexOptions: CodexCliOptions,
+  imagePaths: string[],
   onData: (data: string) => void,
   onError: (error: string) => void,
   onEnd: () => void,
@@ -382,10 +630,7 @@ function queryViaCli(
     os.tmpdir(),
     `code-inspector-codex-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`
   );
-  const commonArgs = buildCommonArgs(codexOptions, outputFile);
-  const args = sessionId
-    ? ['exec', 'resume', ...commonArgs, sessionId, prompt]
-    : ['exec', ...commonArgs, prompt];
+  const args = buildCodexExecArgs(codexOptions, outputFile, imagePaths, prompt, sessionId);
   const env = { ...getEnvVars(), ...codexOptions?.env };
 
   const child = spawn(cliPath, args, {
@@ -412,6 +657,20 @@ function queryViaCli(
     if (ended) return;
     ended = true;
     onEnd();
+  };
+
+  let cleanedArtifacts = false;
+  const cleanupArtifacts = () => {
+    if (cleanedArtifacts) return;
+    cleanedArtifacts = true;
+    try {
+      if (fs.existsSync(outputFile)) {
+        fs.unlinkSync(outputFile);
+      }
+    } catch {
+      // 忽略清理错误
+    }
+    cleanupTempFiles(imagePaths);
   };
 
   const emitToolFromItem = (item: any, done = false) => {
@@ -634,6 +893,7 @@ function queryViaCli(
     hasError = true;
     console.log(chalk.red('[codex-cli error] ') + err.message);
     onError(err.message);
+    cleanupArtifacts();
     finish();
   });
 
@@ -656,14 +916,7 @@ function queryViaCli(
       onError(`Codex CLI exited with code ${code}`);
     }
 
-    try {
-      if (fs.existsSync(outputFile)) {
-        fs.unlinkSync(outputFile);
-      }
-    } catch {
-      // 忽略清理错误
-    }
-
+    cleanupArtifacts();
     finish();
   });
 
@@ -979,12 +1232,13 @@ function buildSDKErrorMessage(event: any): string {
 }
 
 async function queryViaSdk(
-  prompt: string,
+  input: string | CodexRunInputItem[],
   cwd: string,
   codexOptions: CodexSdkOptions,
   sessionId: string | undefined,
   sendSSE: (data: object | string) => void,
-  isAborted: () => boolean
+  isAborted: () => boolean,
+  tempImagePaths: string[]
 ): Promise<{ interrupt?: () => Promise<void> | void } | null> {
   const CodexSDK = await getCodexSDKCtor();
   if (!CodexSDK) {
@@ -1025,7 +1279,7 @@ async function queryViaSdk(
     sendSSE({ type: 'info', model: threadOptions.model });
   }
 
-  const runResult = await thread.runStreamed(prompt);
+  const runResult = await thread.runStreamed(input as any);
   const events = runResult?.events || runResult;
   const toolIndexMap = new Map<string, number>();
   const messageTextMap = new Map<string, string>();
@@ -1086,65 +1340,69 @@ async function queryViaSdk(
     }
   };
 
-  for await (const event of events) {
-    if (isAborted()) {
-      await Promise.resolve(thread.interrupt?.()).catch(() => undefined);
-      break;
-    }
+  try {
+    for await (const event of events) {
+      if (isAborted()) {
+        await Promise.resolve(thread.interrupt?.()).catch(() => undefined);
+        break;
+      }
 
-    if (event?.type === 'error' || event?.type === 'turn.failed') {
-      sendSSE({ error: buildSDKErrorMessage(event) });
-      continue;
-    }
+      if (event?.type === 'error' || event?.type === 'turn.failed') {
+        sendSSE({ error: buildSDKErrorMessage(event) });
+        continue;
+      }
 
-    if (event?.type === 'item.started') {
-      emitToolFromItem(event.item, false);
-      continue;
-    }
+      if (event?.type === 'item.started') {
+        emitToolFromItem(event.item, false);
+        continue;
+      }
 
-    if (event?.type === 'item.updated') {
-      const item = event.item;
-      if (item?.type === 'agent_message' && item?.id) {
-        const current = getItemText(item);
-        const previous = messageTextMap.get(item.id) || '';
-        const delta = current.startsWith(previous) ? current.slice(previous.length) : current;
-        if (delta) {
-          hasAnyText = true;
-          sendSSE({ type: 'text', content: delta });
+      if (event?.type === 'item.updated') {
+        const item = event.item;
+        if (item?.type === 'agent_message' && item?.id) {
+          const current = getItemText(item);
+          const previous = messageTextMap.get(item.id) || '';
+          const delta = current.startsWith(previous) ? current.slice(previous.length) : current;
+          if (delta) {
+            hasAnyText = true;
+            sendSSE({ type: 'text', content: delta });
+          }
+          messageTextMap.set(item.id, current);
+        } else {
+          emitToolFromItem(item, false);
         }
-        messageTextMap.set(item.id, current);
-      } else {
-        emitToolFromItem(item, false);
+        continue;
       }
-      continue;
-    }
 
-    if (event?.type === 'item.completed') {
-      const item = event.item;
-      if (item?.type === 'agent_message' && item?.id) {
-        const current = getItemText(item);
-        const previous = messageTextMap.get(item.id) || '';
-        const delta = current.startsWith(previous) ? current.slice(previous.length) : current;
-        if (delta) {
-          hasAnyText = true;
-          sendSSE({ type: 'text', content: delta });
+      if (event?.type === 'item.completed') {
+        const item = event.item;
+        if (item?.type === 'agent_message' && item?.id) {
+          const current = getItemText(item);
+          const previous = messageTextMap.get(item.id) || '';
+          const delta = current.startsWith(previous) ? current.slice(previous.length) : current;
+          if (delta) {
+            hasAnyText = true;
+            sendSSE({ type: 'text', content: delta });
+          }
+          messageTextMap.delete(item.id);
+        } else {
+          emitToolFromItem(item, true);
         }
-        messageTextMap.delete(item.id);
-      } else {
-        emitToolFromItem(item, true);
+        continue;
       }
-      continue;
-    }
 
-    if (event?.type === 'task_complete') {
-      if (!hasAnyText && typeof event.last_agent_message === 'string' && event.last_agent_message) {
-        hasAnyText = true;
-        sendSSE({ type: 'text', content: event.last_agent_message });
-      } else if (!hasAnyText && typeof event.result === 'string' && event.result) {
-        hasAnyText = true;
-        sendSSE({ type: 'text', content: event.result });
+      if (event?.type === 'task_complete') {
+        if (!hasAnyText && typeof event.last_agent_message === 'string' && event.last_agent_message) {
+          hasAnyText = true;
+          sendSSE({ type: 'text', content: event.last_agent_message });
+        } else if (!hasAnyText && typeof event.result === 'string' && event.result) {
+          hasAnyText = true;
+          sendSSE({ type: 'text', content: event.result });
+        }
       }
     }
+  } finally {
+    cleanupTempFiles(tempImagePaths);
   }
 
   return thread;

--- a/packages/core/types/client/ai.d.ts
+++ b/packages/core/types/client/ai.d.ts
@@ -31,8 +31,14 @@ export interface ContentBlock {
 export interface ChatMessage {
     role: 'user' | 'assistant';
     content: string;
+    modelContent?: string;
     blocks?: ContentBlock[];
     context?: ChatContext | null;
+    images?: ChatImageAttachment[];
+}
+export interface ChatHistoryMessage {
+    role: 'user' | 'assistant';
+    content: string;
 }
 /**
  * 聊天上下文信息（当前选中的元素）
@@ -43,6 +49,13 @@ export interface ChatContext {
     column: number;
     name: string;
 }
+export interface ChatImageAttachment {
+    id: string;
+    name: string;
+    type: string;
+    size: number;
+    previewUrl: string;
+}
 /**
  * 聊天状态接口
  */
@@ -51,6 +64,8 @@ export interface ChatState {
     showCloseConfirm: boolean;
     chatMessages: ChatMessage[];
     chatInput: string;
+    chatPastedImages: ChatImageAttachment[];
+    chatImageProcessing: boolean;
     chatLoading: boolean;
     chatContext: ChatContext | null;
     currentTools: Map<string, ToolCall>;
@@ -71,6 +86,8 @@ export interface ChatHandlers {
     clearChatMessages: () => void;
     handleChatInput: (e: Event) => void;
     handleChatKeyDown: (e: KeyboardEvent) => void;
+    handleChatPaste: (e: ClipboardEvent) => void;
+    removePastedImage: (id: string) => void;
     sendChatMessage: () => void;
     toggleTheme: () => void;
     interruptChat: () => void;
@@ -114,4 +131,4 @@ export declare function fetchModelInfo(ip: string, port: number): Promise<string
 /**
  * 发送聊天消息到服务器
  */
-export declare function sendChatToServer(ip: string, port: number, message: string, context: ChatContext | null, history: ChatMessage[], handlers: StreamHandlers, signal?: AbortSignal, sessionId?: string | null): Promise<void>;
+export declare function sendChatToServer(ip: string, port: number, message: string, context: ChatContext | null, history: ChatHistoryMessage[], handlers: StreamHandlers, signal?: AbortSignal, sessionId?: string | null): Promise<void>;

--- a/packages/core/types/client/index.d.ts
+++ b/packages/core/types/client/index.d.ts
@@ -1,5 +1,5 @@
 import { LitElement, TemplateResult } from 'lit';
-import { ChatMessage, ChatContext, ToolCall } from './ai';
+import { ChatMessage, ChatContext, ChatImageAttachment, ToolCall } from './ai';
 interface Position {
     left?: string;
     right?: string;
@@ -35,6 +35,9 @@ interface ActiveNode {
     content?: string;
     visibility?: 'visible' | 'hidden';
     class?: 'tooltip-top' | 'tooltip-bottom';
+}
+interface PendingChatImageAttachment extends ChatImageAttachment {
+    dataUrl: string;
 }
 export declare class CodeInspectorComponent extends LitElement {
     hotKeys: string;
@@ -109,6 +112,8 @@ export declare class CodeInspectorComponent extends LitElement {
     showCloseConfirm: boolean;
     chatMessages: ChatMessage[];
     chatInput: string;
+    chatPastedImages: PendingChatImageAttachment[];
+    chatImageProcessing: boolean;
     chatLoading: boolean;
     chatContext: ChatContext | null;
     currentTools: Map<string, ToolCall>;
@@ -218,6 +223,13 @@ export declare class CodeInspectorComponent extends LitElement {
     toggleTarget: () => void;
     toggleAICode: () => void;
     private persistAIState;
+    private revokeObjectUrl;
+    private revokeMessageImageUrls;
+    private clearPendingPastedImages;
+    private readFileAsDataUrl;
+    private formatBytes;
+    private buildMessageWithPastedImages;
+    private buildChatHistoryForModel;
     openChatModal: () => void;
     private performCloseChatModal;
     private isTurnRunning;
@@ -229,6 +241,8 @@ export declare class CodeInspectorComponent extends LitElement {
     toggleTheme: () => void;
     handleChatInput: (e: Event) => void;
     handleChatKeyDown: (e: KeyboardEvent) => void;
+    handleChatPaste: (e: ClipboardEvent) => Promise<void>;
+    removePastedImage: (id: string) => void;
     private scrollPending;
     private scrollChatToBottom;
     private startTurnTimer;

--- a/packages/core/types/server/ai-provider-codex.d.ts
+++ b/packages/core/types/server/ai-provider-codex.d.ts
@@ -1,6 +1,37 @@
-import type { CodexOptions } from '../shared';
+import type { CodexOptions, CodexCliOptions } from '../shared';
 import type { AIContext, AIMessage } from './ai';
 import type { ProviderCallbacks, ProviderResult } from './ai-provider-claude';
+interface InlineImagePayload {
+    mediaType: string;
+    data: string;
+}
+type TempImageWriteResult = {
+    imagePaths: string[];
+    failedCount: number;
+};
+type CodexRunInputItem = {
+    type: 'text';
+    text: string;
+} | {
+    type: 'local_image';
+    path: string;
+};
+declare function stripInlineImageDataUrls(text: string): string;
+declare function extractInlineImages(text: string): {
+    text: string;
+    images: InlineImagePayload[];
+};
+declare function persistInlineImagesToTempFiles(images: InlineImagePayload[]): TempImageWriteResult;
+declare function cleanupTempFiles(filePaths: string[]): void;
+declare function buildCodexSdkRunInput(promptText: string, imagePaths: string[]): string | CodexRunInputItem[];
+export declare const __TEST_ONLY__: {
+    stripInlineImageDataUrls: typeof stripInlineImageDataUrls;
+    extractInlineImages: typeof extractInlineImages;
+    persistInlineImagesToTempFiles: typeof persistInlineImagesToTempFiles;
+    cleanupTempFiles: typeof cleanupTempFiles;
+    buildCodexSdkRunInput: typeof buildCodexSdkRunInput;
+    buildCodexExecArgs: typeof buildCodexExecArgs;
+};
 /**
  * 获取模型信息
  * 优先使用用户配置（Codex 暂不通过额外请求探测模型）
@@ -10,3 +41,5 @@ export declare function getModelInfo(codexOptions: CodexOptions | undefined): Pr
  * Codex provider 统一入口
  */
 export declare function handleCodexRequest(message: string, context: AIContext | null, history: AIMessage[], sessionId: string | undefined, cwd: string, codexOptions: CodexOptions | undefined, callbacks: ProviderCallbacks): ProviderResult;
+declare function buildCodexExecArgs(codexOptions: CodexCliOptions, outputFile: string, imagePaths: string[], prompt: string, sessionId?: string): string[];
+export {};

--- a/test/core/server/ai/codex-image-input.test.ts
+++ b/test/core/server/ai/codex-image-input.test.ts
@@ -1,0 +1,102 @@
+import fs from 'fs';
+import { describe, expect, it } from 'vitest';
+import { __TEST_ONLY__ } from '@/core/src/server/ai-provider-codex';
+
+const PNG_DATA_URL = 'data:image/png;base64,aGVsbG8=';
+const JPEG_DATA_URL = 'data:image/jpeg;base64,d29ybGQ=';
+
+describe('codex image input helpers', () => {
+  it('should strip inline image data urls from history text', () => {
+    const text = `before ${PNG_DATA_URL} after`;
+    const stripped = __TEST_ONLY__.stripInlineImageDataUrls(text);
+    expect(stripped).toContain('[Inline image data omitted]');
+    expect(stripped).not.toContain('data:image/png;base64');
+  });
+
+  it('should extract inline images and rewrite text placeholders', () => {
+    const text = `A\n${PNG_DATA_URL}\nB\n${JPEG_DATA_URL}`;
+    const extracted = __TEST_ONLY__.extractInlineImages(text);
+
+    expect(extracted.images).toHaveLength(2);
+    expect(extracted.images[0]).toEqual({
+      mediaType: 'image/png',
+      data: 'aGVsbG8=',
+    });
+    expect(extracted.images[1]).toEqual({
+      mediaType: 'image/jpeg',
+      data: 'd29ybGQ=',
+    });
+    expect(extracted.text).toContain('[Inline image 1 attached separately (image/png)]');
+    expect(extracted.text).toContain('[Inline image 2 attached separately (image/jpeg)]');
+  });
+
+  it('should persist and cleanup temp image files', () => {
+    const { imagePaths, failedCount } = __TEST_ONLY__.persistInlineImagesToTempFiles([
+      { mediaType: 'image/png', data: 'aGVsbG8=' },
+      { mediaType: 'image/jpeg', data: 'd29ybGQ=' },
+    ]);
+
+    expect(failedCount).toBe(0);
+    expect(imagePaths).toHaveLength(2);
+    expect(imagePaths.every((filePath) => fs.existsSync(filePath))).toBe(true);
+    expect(fs.readFileSync(imagePaths[0], 'utf-8')).toBe('hello');
+    expect(fs.readFileSync(imagePaths[1], 'utf-8')).toBe('world');
+
+    __TEST_ONLY__.cleanupTempFiles(imagePaths);
+    expect(imagePaths.every((filePath) => !fs.existsSync(filePath))).toBe(true);
+  });
+
+  it('should build sdk run input with local_image blocks', () => {
+    const prompt = 'describe this screenshot';
+    const asTextOnly = __TEST_ONLY__.buildCodexSdkRunInput(prompt, []);
+    expect(asTextOnly).toBe(prompt);
+
+    const asMultimodal = __TEST_ONLY__.buildCodexSdkRunInput(prompt, ['/tmp/a.png', '/tmp/b.jpg']);
+    expect(asMultimodal).toEqual([
+      { type: 'text', text: prompt },
+      { type: 'local_image', path: '/tmp/a.png' },
+      { type: 'local_image', path: '/tmp/b.jpg' },
+    ]);
+  });
+
+  it('should build cli args with option separator when images are attached', () => {
+    const args = __TEST_ONLY__.buildCodexExecArgs(
+      {},
+      '/tmp/out.txt',
+      ['/tmp/a.png'],
+      'hello prompt'
+    );
+    expect(args).toEqual([
+      'exec',
+      '--json',
+      '-o',
+      '/tmp/out.txt',
+      '--image',
+      '/tmp/a.png',
+      '--',
+      'hello prompt',
+    ]);
+  });
+
+  it('should build resume cli args with option separator when images are attached', () => {
+    const args = __TEST_ONLY__.buildCodexExecArgs(
+      {},
+      '/tmp/out.txt',
+      ['/tmp/a.png'],
+      'hello prompt',
+      'session-1'
+    );
+    expect(args).toEqual([
+      'exec',
+      'resume',
+      '--json',
+      '-o',
+      '/tmp/out.txt',
+      '--image',
+      '/tmp/a.png',
+      '--',
+      'session-1',
+      'hello prompt',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
  修复 AI 聊天在图片输入场景下的多模态处理链路，覆盖前端消息构造、Claude
  Provider、Codex Provider（CLI + SDK）和类型声明。

  ## Changes
  1. 前端聊天支持粘贴图片并预览/删除，发送时区分展示文本与模型输入文本（包含图片
  data URL）。
  2. Claude Provider 支持从消息中提取 inline image data URL，并在 CLI/SDK 以多模
  态方式发送。
  3. Codex Provider 支持从消息中提取 inline image data URL：
     - CLI：通过 `--image` 发送图片
     - SDK：通过 `local_image` 输入发送
     - 增加 fallback、临时文件清理、会话续传上下文处理
  4. 新增 Codex 图片输入相关测试。
  5. 同步更新 client/server d.ts 类型声明。

  ## Testing
  - `pnpm vitest run test/core/server/ai/*.test.ts`
  - `pnpm -C packages/core exec tsc -p tsconfig.json --emitDeclarationOnly false
  --declaration false --noEmit`

  本次 commit 涉及文件：

  - packages/core/src/client/ai.ts
  - packages/core/src/client/index.ts
  - packages/core/src/server/ai-provider-claude.ts
  - packages/core/src/server/ai-provider-codex.ts
  - packages/core/types/client/ai.d.ts
  - packages/core/types/client/index.d.ts
  - packages/core/types/server/ai-provider-codex.d.ts
  - test/core/server/ai/codex-image-input.test.ts