### PR TITLE
feat: 支持 vue 的 template 与 js 分开定义的模式（非标准 vue 文件）

### DIFF
--- a/packages/core/src/server/transform/index.ts
+++ b/packages/core/src/server/transform/index.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 import { transformJsx } from './transform-jsx';
 import { transformSvelte } from './transform-svelte';
-import { transformVue } from './transform-vue';
+import { transformVue, transformVueHtml } from './transform-vue';
 import { EscapeTags, PathType, isIgnoredFile } from '../../shared';
 import { getRelativeOrAbsolutePath } from '../server';
 
-type FileType = 'vue' | 'jsx' | 'svelte' | unknown;
+type FileType = 'vue' | 'vue-html' | 'jsx' | 'svelte' | unknown;
 
 type TransformCodeParams = {
   content: string;
@@ -49,6 +49,8 @@ export function transformCode(params: TransformCodeParams) {
   try {
     if (fileType === 'vue') {
       return transformVue(content, filePath, finalEscapeTags);
+    } else if (fileType === 'vue-html') {
+      return transformVueHtml(content, filePath, finalEscapeTags);
     } else if (fileType === 'jsx') {
       return transformJsx(content, filePath, finalEscapeTags);
     } else if (fileType === 'svelte') {

--- a/packages/core/src/server/transform/transform-vue.ts
+++ b/packages/core/src/server/transform/transform-vue.ts
@@ -106,3 +106,27 @@ function transformVueTemplate(
     ],
   });
 }
+
+/**
+ * Transform standalone HTML template files used as Vue templates.
+ * These are .html files that contain Vue template syntax and are loaded via
+ * require('./xxx.html') rather than through vue-loader's SFC mechanism.
+ *
+ * Unlike transformVue which handles full .vue SFC files, this function
+ * directly parses the HTML content as a Vue template fragment.
+ */
+export function transformVueHtml(
+  content: string,
+  filePath: string,
+  escapeTags: EscapeTags
+) {
+  const s = new MagicString(content);
+
+  const ast = parse(content, {
+    comments: true,
+  });
+
+  transformVueTemplate(ast, filePath, escapeTags, s);
+
+  return s.toString();
+}

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -366,7 +366,7 @@ export function isIgnoredFile({
   fileType,
 }: {
   content: string;
-  fileType: 'vue' | 'jsx' | 'svelte' | unknown;
+  fileType: 'vue' | 'vue-html' | 'jsx' | 'svelte' | unknown;
 }): boolean {
   if (!content) {
     return false;
@@ -374,8 +374,8 @@ export function isIgnoredFile({
   const trimmed = content.trimStart();
   const directives = ['code-inspector-disable', 'code-inspector-ignore'];
 
-  // Vue / Svelte - check HTML comments
-  if (fileType === 'vue' || fileType === 'svelte') {
+  // Vue / Vue HTML / Svelte - check HTML comments
+  if (fileType === 'vue' || fileType === 'vue-html' || fileType === 'svelte') {
     if (trimmed.startsWith('<!--')) {
       const endIndex = trimmed.indexOf('-->');
       if (endIndex !== -1) {

--- a/packages/core/types/server/transform/index.d.ts
+++ b/packages/core/types/server/transform/index.d.ts
@@ -1,5 +1,5 @@
 import { EscapeTags, PathType } from '../../shared';
-type FileType = 'vue' | 'jsx' | 'svelte' | unknown;
+type FileType = 'vue' | 'vue-html' | 'jsx' | 'svelte' | unknown;
 type TransformCodeParams = {
     content: string;
     filePath: string;

--- a/packages/core/types/server/transform/transform-vue.d.ts
+++ b/packages/core/types/server/transform/transform-vue.d.ts
@@ -1,2 +1,11 @@
 import { EscapeTags } from '../../shared';
 export declare function transformVue(content: string, filePath: string, escapeTags: EscapeTags): string;
+/**
+ * Transform standalone HTML template files used as Vue templates.
+ * These are .html files that contain Vue template syntax and are loaded via
+ * require('./xxx.html') rather than through vue-loader's SFC mechanism.
+ *
+ * Unlike transformVue which handles full .vue SFC files, this function
+ * directly parses the HTML content as a Vue template fragment.
+ */
+export declare function transformVueHtml(content: string, filePath: string, escapeTags: EscapeTags): string;

--- a/packages/core/types/shared/utils.d.ts
+++ b/packages/core/types/shared/utils.d.ts
@@ -133,6 +133,6 @@ export declare function hasWritePermission(filePath: string): boolean;
  */
 export declare function isIgnoredFile({ content, fileType, }: {
     content: string;
-    fileType: 'vue' | 'jsx' | 'svelte' | unknown;
+    fileType: 'vue' | 'vue-html' | 'jsx' | 'svelte' | unknown;
 }): boolean;
 export {};

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -37,6 +37,11 @@ const applyLoader = (options: LoaderOptions, compiler: any) => {
   const module = _compiler?.options?.module;
   /* v8 ignore next -- fallback for legacy webpack versions with module.loaders */
   const rules = module?.rules || module?.loaders || [];
+  // Determine the file match pattern, supporting both default and user-configured patterns
+  const matchPattern = options.match ?? /\.(vue|jsx|tsx|js|ts|mjs|mts|svelte)$/;
+  // Check if user's match pattern includes .html
+  const matchIncludesHtml = matchPattern instanceof RegExp && matchPattern.test('.html');
+
   rules.push(
     {
       test: options.match ?? /\.html$/,
@@ -49,8 +54,26 @@ const applyLoader = (options: LoaderOptions, compiler: any) => {
       ],
       ...(options.enforcePre === false ? {} : { enforce: 'pre' }),
     },
+    // If user's match pattern includes .html, add a separate rule for standalone .html files
+    // These are HTML template files used as Vue templates via require('./xxx.html')
+    ...(matchIncludesHtml
+      ? [
+          {
+            test: /\.html$/,
+            use: [
+              {
+                loader: path.resolve(compatibleDirname, `./loader.js`),
+                options,
+              },
+            ],
+            ...(options.enforcePre === false ? {} : { enforce: 'pre' }),
+          },
+        ]
+      : []),
     {
-      test: /\.(vue|jsx|tsx|js|ts|mjs|mts|svelte)$/,
+      test: matchIncludesHtml
+        ? /\.(vue|jsx|tsx|js|ts|mjs|mts|svelte)$/
+        : matchPattern,
       use: [
         {
           loader: path.resolve(compatibleDirname, `./loader.js`),

--- a/packages/webpack/src/loader.ts
+++ b/packages/webpack/src/loader.ts
@@ -76,11 +76,19 @@ export default async function WebpackCodeInspectorLoader(content: string) {
     filePath.endsWith('.html') &&
     params.get('type') === 'template' &&
     params.has('vue');
-  if (isVue || isHtmlVue) {
+  // Standalone HTML template files (used as Vue templates via require('./xxx.html'))
+  // These are HTML files that contain Vue template syntax but are not loaded through
+  // vue-loader's ?vue query mechanism
+  const isStandaloneHtmlTemplate =
+    filePath.endsWith('.html') &&
+    !params.has('vue') &&
+    options.match instanceof RegExp &&
+    options.match.test('.html');
+  if (isVue || isHtmlVue || isStandaloneHtmlTemplate) {
     return transformCode({
       content,
       filePath,
-      fileType: 'vue',
+      fileType: isStandaloneHtmlTemplate ? 'vue-html' : 'vue',
       escapeTags,
       pathType: options.pathType,
     });


### PR DESCRIPTION
# code-inspector-plugin 支持分离式 Vue HTML 模板文件

## 问题
某些项目中 Vue 代码采用 `.js` + `.html` 分离式写法，HTML 模板通过 `require("./xxx.html")` 引入。`code-inspector-plugin` 无法为这类 HTML 模板文件注入 `data-insp-path` 定位属性。

## 根因
插件的 webpack loader 对 `.html` 文件只处理带 `?vue&type=template` query 的情况（通过 vue-loader 的 SFC 机制），直接 `require` 的 HTML 文件不会触发转换。

## 修改文件
1. **`packages/webpack/src/index.ts`** - 新增独立 `.html` 文件的 loader 规则（`enforce: 'pre'`）
2. **`packages/webpack/src/loader.ts`** - 新增 `isStandaloneHtmlTemplate` 判断分支
3. **`packages/core/src/server/transform/index.ts`** - 新增 `vue-html` 文件类型处理
4. **`packages/core/src/server/transform/transform-vue.ts`** - 新增 `transformVueHtml` 函数