### PR TITLE
feat(core): add AI conversation history persistence and expireDays option

### DIFF
--- a/docs/en/api/advance.md
+++ b/docs/en/api/advance.md
@@ -23,6 +23,20 @@ Below are configurations for some non-standard scenarios.
      * String type, can use {file}, {line}, {column} templates to replace code location information.
      */
     target?: string;
+    /**
+     * AI assistant configuration, see AI Assistant docs for details
+     */
+    ai?: {
+      claudeCode?: boolean | ClaudeCodeOptions;
+      codex?: boolean | CodexOptions;
+      opencode?: boolean | OpenCodeOptions;
+      /** Conversation history expiration in days, defaults to 0 (no auto-cleanup) */
+      expireDays?: number;
+    };
+    /**
+     * Default click action: 'copy' | 'locate' | 'target' | 'ai'
+     */
+    defaultAction?: 'copy' | 'locate' | 'target' | 'ai';
   };
   ```
 - Description: In some scenarios, if you don't need to locate code when clicking elements and only need to copy the source code location information, you can set `locate: false` and `copy: true`. In this case, clicking elements will only copy the source code location information.

--- a/docs/en/guide/feature/ai.md
+++ b/docs/en/guide/feature/ai.md
@@ -433,3 +433,24 @@ type ClaudeSdkOptions = {
 :::
 
 For more Claude SDK details, see [Claude Code Agent SDK](https://platform.claude.com/docs/agent-sdk/typescript).
+
+## Conversation History
+
+The AI Assistant automatically saves each Q&A to the `node_modules/.code-inspector/` directory in your project. Click the clock icon in the top-right corner of the chat dialog to browse history. Select an entry to restore its conversation context.
+
+### expireDays
+
+- Optional
+- Type: `number`, default `0`
+- Description: Number of days before conversation history expires. Defaults to `0` (no auto-cleanup). When set to a positive integer, opening the history list will automatically clean up records older than the specified number of days.
+
+```js
+codeInspectorPlugin({
+  behavior: {
+    ai: {
+      codex: true,
+      expireDays: 30, // auto-cleanup history older than 30 days
+    },
+  },
+}),
+```

--- a/docs/zh/api/advance.md
+++ b/docs/zh/api/advance.md
@@ -23,6 +23,20 @@
      * 字符串类型，可通过 {file}、{line}、{column} 模版代替源码位置信息，跳转前会将模板替换为对应的值
      */
     target?: string;
+    /**
+     * AI 助手配置，详见 AI 助手文档
+     */
+    ai?: {
+      claudeCode?: boolean | ClaudeCodeOptions;
+      codex?: boolean | CodexOptions;
+      opencode?: boolean | OpenCodeOptions;
+      /** 对话历史过期天数，默认 0 不自动清理 */
+      expireDays?: number;
+    };
+    /**
+     * 默认点击行为：'copy' | 'locate' | 'target' | 'ai'
+     */
+    defaultAction?: 'copy' | 'locate' | 'target' | 'ai';
   };
   ```
 - 说明：在某些场景下，如果你在点击元素时不需要定位代码，仅需要复制元素的源码位置信息，则可以设置 `locate: false` 和 `copy: true`，此时点击元素仅会复制源码位置信息。

--- a/docs/zh/guide/feature/ai.md
+++ b/docs/zh/guide/feature/ai.md
@@ -433,3 +433,24 @@ type ClaudeSdkOptions = {
 :::
 
 更多 Claude SDK 参数说明可参考 [Claude Code Agent SDK](https://platform.claude.com/docs/zh-CN/agent-sdk/typescript)。
+
+## 对话历史
+
+AI 助手会自动将每次问答保存到项目目录下的 `node_modules/.code-inspector/` 目录中。你可以在对话框右上角点击时钟图标查看历史记录，选择历史条目即可恢复对话上下文。
+
+### expireDays
+
+- 可选项
+- 类型：`number`，默认值为 `0`
+- 说明：对话历史的过期天数。默认为 `0`，不自动清理历史记录。设置为正整数时，打开历史列表会自动清理超过指定天数的记录。
+
+```js
+codeInspectorPlugin({
+  behavior: {
+    ai: {
+      codex: true,
+      expireDays: 30, // 自动清理 30 天前的对话历史
+    },
+  },
+}),
+```

--- a/packages/core/src/client/ai-persist.ts
+++ b/packages/core/src/client/ai-persist.ts
@@ -21,6 +21,7 @@ export interface PersistedAIState {
   modalPosition: { left: string; top: string } | null;
   turnStatus: 'idle' | 'running' | 'done' | 'interrupt';
   revertedToolIds?: string[];
+  conversationId?: string | null;
 }
 
 /**

--- a/packages/core/src/client/ai.ts
+++ b/packages/core/src/client/ai.ts
@@ -101,6 +101,30 @@ export interface AIModelInfo {
 }
 
 /**
+ * 对话历史条目
+ */
+export interface HistoryEntry {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  provider: string | null;
+  messageCount: number;
+}
+
+/**
+ * 完整对话数据
+ */
+export interface ConversationData {
+  messages: ChatMessage[];
+  context: ChatContext | null;
+  sessionId: string | null;
+  provider: ChatProvider | null;
+  model: string;
+  revertedToolIds: string[];
+}
+
+/**
  * 聊天状态接口
  */
 export interface ChatState {
@@ -125,6 +149,10 @@ export interface ChatState {
   showModelMenu: boolean;
   revertedToolIds: Set<string>;
   revertingToolIds: Set<string>;
+  conversationId: string | null;
+  showHistoryPanel: boolean;
+  historyList: HistoryEntry[];
+  historyLoading: boolean;
 }
 
 /**
@@ -154,6 +182,10 @@ export interface ChatHandlers {
   handleOverlayClick: () => void;
   revertEdit: (tool: ToolCall) => void;
   revertAllEdits: () => void;
+  toggleHistoryPanel: () => void;
+  loadConversation: (id: string) => void;
+  deleteConversation: (id: string) => void;
+  startNewConversation: () => void;
 }
 
 /**
@@ -281,6 +313,19 @@ function formatDuration(seconds: number): string {
     return `${mins}m ${secs.toString().padStart(2, '0')}s`;
   }
   return `${secs}s`;
+}
+
+function formatHistoryDate(timestamp: number): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diff = now.getTime() - timestamp;
+  if (diff < 60000) return 'Just now';
+  if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
+  if (date.getFullYear() === now.getFullYear()) {
+    return `${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')} ${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+  }
+  return `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
 }
 
 /**
@@ -1298,6 +1343,25 @@ export function renderChatModal(
           </div>
           <div class="chat-modal-actions">
             <button
+              class="chat-modal-history"
+              @click="${handlers.toggleHistoryPanel}"
+              title="History"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+            </button>
+            <button
               class="chat-modal-theme"
               @click="${handlers.toggleTheme}"
               title="${state.chatTheme === 'dark'
@@ -1368,37 +1432,103 @@ export function renderChatModal(
             </button>
           </div>
         </div>
-        <div class="chat-modal-content">
-          ${state.chatMessages.length === 0
-            ? html`<div class="chat-empty">
-                <span class="chat-empty-prompt">❯</span>
-                <span class="chat-empty-text"
-                  >Ask me anything about this code...</span
-                >
-              </div>`
-            : state.chatMessages.map(
-                (msg) => html`
-                  <div class="chat-line chat-line-${msg.role}">
-                    ${msg.role === 'user'
-                      ? html`<span class="chat-prompt">❯</span>`
-                      : html`<span class="chat-indent"></span>`}
-                    <div class="chat-message-content">
-                      ${renderMessageContext(msg)}
-                      ${renderMessageContent(msg, state, handlers)}
-                    </div>
-                  </div>
-                `,
-              )}
-          ${state.chatLoading &&
-          (!state.chatMessages.length ||
-            state.chatMessages[state.chatMessages.length - 1]?.role === 'user')
-            ? html`<div class="chat-loading">
-                <span class="chat-indent"></span>
-                <span class="chat-cursor"></span>
-              </div>`
-            : ''}
-        </div>
-        ${state.turnStatus !== 'idle'
+        ${state.showHistoryPanel
+          ? html`<div class="chat-history-panel">
+              <div class="chat-history-header">
+                <span class="chat-history-title">History</span>
+                <div class="chat-history-actions">
+                  <button
+                    class="chat-history-new-btn"
+                    @click="${handlers.startNewConversation}"
+                    title="New conversation"
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M12 5v14" />
+                      <path d="M5 12h14" />
+                    </svg>
+                    New
+                  </button>
+                  <button
+                    class="chat-history-back-btn"
+                    @click="${handlers.toggleHistoryPanel}"
+                    title="Back to chat"
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M18 6 6 18" />
+                      <path d="m6 6 12 12" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div class="chat-history-list">
+                ${state.historyLoading
+                  ? html`<div class="chat-history-loading">
+                      <span class="chat-cursor"></span>
+                      <span>Loading...</span>
+                    </div>`
+                  : state.historyList.length === 0
+                    ? html`<div class="chat-history-empty">No history yet</div>`
+                    : state.historyList.map(
+                        (entry) => html`
+                          <div
+                            class="chat-history-item ${entry.id === state.conversationId ? 'active' : ''}"
+                            @click="${() => handlers.loadConversation(entry.id)}"
+                          >
+                            <div class="chat-history-item-info">
+                              <span class="chat-history-item-title">${entry.title || 'Untitled'}</span>
+                              <span class="chat-history-item-meta">
+                                ${formatHistoryDate(entry.updatedAt)}
+                                ${entry.provider ? html` · <span class="chat-history-item-provider">${entry.provider}</span>` : ''}
+                                · ${entry.messageCount} msgs
+                              </span>
+                            </div>
+                            <button
+                              class="chat-history-item-delete"
+                              @click="${(e: MouseEvent) => { e.stopPropagation(); handlers.deleteConversation(entry.id); }}"
+                              title="Delete"
+                            >
+                              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M3 6h18" />
+                                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+                                <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                              </svg>
+                            </button>
+                          </div>
+                        `,
+                      )}
+              </div>
+            </div>`
+          : html`<div class="chat-modal-content">
+              ${state.chatMessages.length === 0
+                ? html`<div class="chat-empty">
+                    <span class="chat-empty-prompt">❯</span>
+                    <span class="chat-empty-text"
+                      >Ask me anything about this code...</span
+                    >
+                  </div>`
+                : state.chatMessages.map(
+                    (msg) => html`
+                      <div class="chat-line chat-line-${msg.role}">
+                        ${msg.role === 'user'
+                          ? html`<span class="chat-prompt">❯</span>`
+                          : html`<span class="chat-indent"></span>`}
+                        <div class="chat-message-content">
+                          ${renderMessageContext(msg)}
+                          ${renderMessageContent(msg, state, handlers)}
+                        </div>
+                      </div>
+                    `,
+                  )}
+              ${state.chatLoading &&
+              (!state.chatMessages.length ||
+                state.chatMessages[state.chatMessages.length - 1]?.role === 'user')
+                ? html`<div class="chat-loading">
+                    <span class="chat-indent"></span>
+                    <span class="chat-cursor"></span>
+                  </div>`
+                : ''}
+            </div>`}
+        ${!state.showHistoryPanel && state.turnStatus !== 'idle'
           ? html`<div class="chat-status-bar">
               <div class="chat-status-info">
                 <span class="chat-status-icon ${state.turnStatus}">
@@ -1449,7 +1579,8 @@ export function renderChatModal(
                   : ''}
             </div>`
           : ''}
-        <div class="chat-modal-footer">
+        ${!state.showHistoryPanel
+          ? html`<div class="chat-modal-footer">
           ${state.chatPastedImages.length > 0
             ? html`<div class="chat-paste-preview">
                 ${state.chatPastedImages.map(
@@ -1523,8 +1654,8 @@ export function renderChatModal(
                   <path d="M12 5l7 7-7 7" />
                 </svg>`}
           </button>
-        </div>
-
+        </div>`
+          : ''}
         ${state.showCloseConfirm
           ? html`<div
               class="chat-close-confirm-overlay"
@@ -1996,7 +2127,8 @@ export const chatStyles = css`
   }
 
   .chat-modal-theme,
-  .chat-modal-clear {
+  .chat-modal-clear,
+  .chat-modal-history {
     background: transparent;
     border: none;
     color: var(--chat-text-muted);
@@ -2010,7 +2142,8 @@ export const chatStyles = css`
   }
 
   .chat-modal-theme:hover,
-  .chat-modal-clear:hover {
+  .chat-modal-clear:hover,
+  .chat-modal-history:hover {
     background: var(--chat-hover-bg);
     color: var(--chat-text-secondary);
   }
@@ -2874,6 +3007,158 @@ export const chatStyles = css`
   .chat-modal-content::-webkit-scrollbar-thumb:hover {
     background: var(--chat-scrollbar-hover);
   }
+
+  /* History Panel */
+  .chat-history-panel {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .chat-history-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--chat-border);
+    flex-shrink: 0;
+  }
+
+  .chat-history-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--chat-text-primary);
+  }
+
+  .chat-history-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .chat-history-new-btn,
+  .chat-history-back-btn {
+    background: transparent;
+    border: none;
+    color: var(--chat-text-muted);
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    font-family: inherit;
+    transition: all 0.15s;
+  }
+
+  .chat-history-new-btn:hover,
+  .chat-history-back-btn:hover {
+    background: var(--chat-hover-bg);
+    color: var(--chat-text-secondary);
+  }
+
+  .chat-history-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 4px 0;
+  }
+
+  .chat-history-list::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  .chat-history-list::-webkit-scrollbar-track {
+    background: var(--chat-scrollbar-track);
+  }
+
+  .chat-history-list::-webkit-scrollbar-thumb {
+    background: var(--chat-scrollbar-thumb);
+    border-radius: 4px;
+  }
+
+  .chat-history-loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 16px;
+    color: var(--chat-text-muted);
+    font-size: 13px;
+  }
+
+  .chat-history-empty {
+    padding: 32px 16px;
+    text-align: center;
+    color: var(--chat-text-muted);
+    font-size: 13px;
+  }
+
+  .chat-history-item {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+    cursor: pointer;
+    transition: background 0.15s;
+    gap: 8px;
+  }
+
+  .chat-history-item:hover {
+    background: var(--chat-hover-bg);
+  }
+
+  .chat-history-item.active {
+    background: var(--chat-hover-bg);
+    border-left: 2px solid var(--chat-accent);
+  }
+
+  .chat-history-item-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .chat-history-item-title {
+    font-size: 13px;
+    color: var(--chat-text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .chat-history-item-meta {
+    font-size: 11px;
+    color: var(--chat-text-muted);
+  }
+
+  .chat-history-item-provider {
+    text-transform: capitalize;
+  }
+
+  .chat-history-item-delete {
+    background: transparent;
+    border: none;
+    color: var(--chat-text-muted);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    opacity: 0;
+    transition: all 0.15s;
+    flex-shrink: 0;
+  }
+
+  .chat-history-item:hover .chat-history-item-delete {
+    opacity: 1;
+  }
+
+  .chat-history-item-delete:hover {
+    background: var(--chat-hover-bg);
+    color: var(--chat-error);
+  }
 `;
 
 /**
@@ -2996,6 +3281,97 @@ export async function revertEdit(
       success: false,
       error: 'network_error',
     }));
+  }
+}
+
+/**
+ * 获取对话历史列表
+ */
+export async function fetchHistoryList(
+  ip: string,
+  port: number,
+): Promise<HistoryEntry[]> {
+  try {
+    const response = await fetch(`http://${ip}:${port}/ai/history`);
+    if (!response.ok) return [];
+    const data = await response.json();
+    return Array.isArray(data?.conversations) ? data.conversations : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 保存对话到服务端
+ */
+export async function saveConversation(
+  ip: string,
+  port: number,
+  data: {
+    id?: string | null;
+    messages: ChatMessage[];
+    context: ChatContext | null;
+    sessionId: string | null;
+    provider: ChatProvider | null;
+    model: string;
+    revertedToolIds: string[];
+  },
+): Promise<{ id: string; success: boolean }> {
+  try {
+    const response = await fetch(`http://${ip}:${port}/ai/history/save`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) return { id: '', success: false };
+    return await response.json();
+  } catch {
+    return { id: '', success: false };
+  }
+}
+
+/**
+ * 加载对话历史
+ */
+export async function loadConversationData(
+  ip: string,
+  port: number,
+  id: string,
+): Promise<ConversationData | null> {
+  try {
+    const response = await fetch(`http://${ip}:${port}/ai/history/load`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    });
+    if (!response.ok) return null;
+    const data = await response.json();
+    if (data?.error) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 删除对话历史
+ */
+export async function deleteConversationData(
+  ip: string,
+  port: number,
+  id: string,
+): Promise<boolean> {
+  try {
+    const response = await fetch(`http://${ip}:${port}/ai/history/delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    });
+    if (!response.ok) return false;
+    const data = await response.json();
+    return data?.success === true;
+  } catch {
+    return false;
   }
 }
 

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -12,6 +12,7 @@ import {
   ChatHistoryMessage,
   ContentBlock,
   ToolCall,
+  HistoryEntry,
   renderChatModal,
   chatStyles,
   sendChatToServer,
@@ -20,6 +21,10 @@ import {
   fetchModelInfo,
   revertEdit,
   collectRevertableTools,
+  fetchHistoryList,
+  saveConversation,
+  loadConversationData,
+  deleteConversationData,
 } from './ai';
 import { saveAIState, loadAIState, clearAIState } from './ai-persist';
 
@@ -239,6 +244,14 @@ export class CodeInspectorComponent extends LitElement {
   revertedToolIds: Set<string> = new Set();
   @state()
   revertingToolIds: Set<string> = new Set();
+  @state()
+  conversationId: string | null = null;
+  @state()
+  showHistoryPanel = false;
+  @state()
+  historyList: HistoryEntry[] = [];
+  @state()
+  historyLoading = false;
 
   // 中断控制器和计时器
   private chatAbortController: AbortController | null = null;
@@ -1265,6 +1278,7 @@ export class CodeInspectorComponent extends LitElement {
         this.revertedToolIds.size > 0
           ? Array.from(this.revertedToolIds)
           : undefined,
+      conversationId: this.conversationId,
     });
   };
 
@@ -1681,6 +1695,33 @@ export class CodeInspectorComponent extends LitElement {
     }
     this.turnDuration = Math.floor((Date.now() - this.turnStartTime) / 1000);
     this.turnStatus = status;
+
+    // 自动保存对话到服务端
+    if (status === 'done' && this.chatMessages.length > 0) {
+      this.autoSaveConversation();
+    }
+  };
+
+  // 自动保存对话到服务端
+  private autoSaveConversation = async () => {
+    try {
+      await saveConversation(
+        this.ip || 'localhost',
+        this.port,
+        {
+          messages: this.chatMessages,
+          context: this.chatContext,
+          sessionId: this.chatSessionId,
+          provider: this.chatProvider,
+          model: this.chatModel,
+          revertedToolIds: this.revertedToolIds.size > 0
+            ? Array.from(this.revertedToolIds)
+            : [],
+        },
+      );
+    } catch {
+      // 保存失败静默
+    }
   };
 
   // 中断聊天
@@ -1813,6 +1854,89 @@ export class CodeInspectorComponent extends LitElement {
     for (const tool of tools) {
       await this.handleRevertEdit(tool);
     }
+  };
+
+  // 切换历史面板
+  toggleHistoryPanel = async () => {
+    this.showHistoryPanel = !this.showHistoryPanel;
+    if (this.showHistoryPanel) {
+      this.historyLoading = true;
+      try {
+        this.historyList = await fetchHistoryList(
+          this.ip || 'localhost',
+          this.port,
+        );
+      } catch {
+        this.historyList = [];
+      } finally {
+        this.historyLoading = false;
+      }
+    }
+  };
+
+  // 加载历史对话
+  handleLoadConversation = async (id: string) => {
+    try {
+      const data = await loadConversationData(
+        this.ip || 'localhost',
+        this.port,
+        id,
+      );
+      if (!data) return;
+
+      this.chatMessages = data.messages;
+      this.chatContext = data.context;
+      this.chatSessionId = data.sessionId;
+      if (data.provider) {
+        this.chatProvider = data.provider;
+      }
+      if (data.model) {
+        this.chatModel = data.model;
+      }
+      this.revertedToolIds = new Set(data.revertedToolIds || []);
+      this.conversationId = id;
+      this.showHistoryPanel = false;
+      this.turnStatus = 'idle';
+      this.persistAIState();
+    } catch {
+      // 静默
+    }
+  };
+
+  // 删除历史对话
+  handleDeleteConversation = async (id: string) => {
+    try {
+      const success = await deleteConversationData(
+        this.ip || 'localhost',
+        this.port,
+        id,
+      );
+      if (success) {
+        this.historyList = this.historyList.filter((h) => h.id !== id);
+        if (this.conversationId === id) {
+          this.conversationId = null;
+          this.chatMessages = [];
+          this.chatContext = null;
+          this.chatSessionId = null;
+          this.revertedToolIds = new Set();
+          this.turnStatus = 'idle';
+          this.persistAIState();
+        }
+      }
+    } catch {
+      // 静默
+    }
+  };
+
+  // 新建对话
+  handleStartNewConversation = () => {
+    this.chatMessages = [];
+    this.conversationId = null;
+    this.chatSessionId = null;
+    this.revertedToolIds = new Set();
+    this.turnStatus = 'idle';
+    this.showHistoryPanel = false;
+    this.persistAIState();
   };
 
   // 聊天框拖拽开始
@@ -2316,6 +2440,7 @@ export class CodeInspectorComponent extends LitElement {
       this.chatProvider = persisted.chatProvider || null;
       this.availableAIProviders = persisted.availableAIProviders || [];
       this.revertedToolIds = new Set(persisted.revertedToolIds || []);
+      this.conversationId = persisted.conversationId || null;
       this.showChatModal = true;
 
       if (this.chatTheme === 'light') {
@@ -2691,6 +2816,10 @@ export class CodeInspectorComponent extends LitElement {
             showModelMenu: this.showModelMenu,
             revertedToolIds: this.revertedToolIds,
             revertingToolIds: this.revertingToolIds,
+            conversationId: this.conversationId,
+            showHistoryPanel: this.showHistoryPanel,
+            historyList: this.historyList,
+            historyLoading: this.historyLoading,
           },
           {
             closeChatModal: this.closeChatModal,
@@ -2716,6 +2845,10 @@ export class CodeInspectorComponent extends LitElement {
             handleOverlayClick: this.handleOverlayClick,
             revertEdit: this.handleRevertEdit,
             revertAllEdits: this.handleRevertAllEdits,
+            toggleHistoryPanel: this.toggleHistoryPanel,
+            loadConversation: this.handleLoadConversation,
+            deleteConversation: this.handleDeleteConversation,
+            startNewConversation: this.handleStartNewConversation,
           }
         )}
 

--- a/packages/core/src/server/ai-history.ts
+++ b/packages/core/src/server/ai-history.ts
@@ -1,0 +1,279 @@
+/**
+ * AI 对话历史持久化 - 服务端文件存储
+ * 将对话历史保存到 node_modules/.code-inspector/ 目录
+ */
+import fs from 'fs';
+import path from 'path';
+import http from 'http';
+
+const HISTORY_DIR_NAME = path.join('node_modules', '.code-inspector');
+const INDEX_FILE = 'history-index.json';
+
+export interface HistoryEntry {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  provider: string | null;
+  messageCount: number;
+}
+
+function getHistoryDir(projectRootPath: string): string {
+  const root = projectRootPath || process.cwd();
+  return path.join(root, HISTORY_DIR_NAME);
+}
+
+function ensureHistoryDir(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function readIndex(dir: string): Record<string, HistoryEntry> {
+  const indexPath = path.join(dir, INDEX_FILE);
+  try {
+    if (!fs.existsSync(indexPath)) return {};
+    return JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeIndex(dir: string, index: Record<string, HistoryEntry>): void {
+  const indexPath = path.join(dir, INDEX_FILE);
+  fs.writeFileSync(indexPath, JSON.stringify(index, null, 2), 'utf-8');
+}
+
+function cleanupExpired(dir: string, expireDays: number): void {
+  if (expireDays <= 0) return;
+  const index = readIndex(dir);
+  const now = Date.now();
+  const maxAge = expireDays * 86400000;
+  let changed = false;
+
+  const ids = Object.keys(index);
+  for (let i = 0; i < ids.length; i++) {
+    const id = ids[i];
+    const entry = index[id];
+    if (entry.createdAt + maxAge < now) {
+      const filePath = path.join(dir, `${id}.json`);
+      try {
+        if (fs.existsSync(filePath)) {
+          fs.unlinkSync(filePath);
+        }
+      } catch {
+        // 静默
+      }
+      delete index[id];
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    writeIndex(dir, index);
+  }
+}
+
+function extractTitle(messages: any[]): string {
+  if (!Array.isArray(messages)) return '';
+  let title = '';
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i]?.role === 'user' && typeof messages[i]?.content === 'string') {
+      const text = messages[i].content.trim();
+      title = text.length > 80 ? text.slice(0, 80) + '...' : text;
+    }
+  }
+  return title;
+}
+
+async function readBody(req: http.IncomingMessage): Promise<string> {
+  let body = '';
+  for await (const chunk of req) {
+    body += chunk;
+  }
+  return body;
+}
+
+/**
+ * 获取对话历史列表
+ */
+export async function handleAIHistoryListRequest(
+  res: http.ServerResponse,
+  corsHeaders: Record<string, string>,
+  projectRootPath: string,
+  expireDays: number,
+): Promise<void> {
+  const dir = getHistoryDir(projectRootPath);
+
+  try {
+    ensureHistoryDir(dir);
+    if (expireDays > 0) {
+      cleanupExpired(dir, expireDays);
+    }
+    const index = readIndex(dir);
+    // 按 updatedAt 降序排列
+    const conversations = Object.keys(index)
+      .map((id) => ({ ...index[id], id }))
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+
+    res.writeHead(200, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ conversations }));
+  } catch {
+    res.writeHead(200, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ conversations: [] }));
+  }
+}
+
+/**
+ * 保存对话
+ */
+export async function handleAIHistorySaveRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  corsHeaders: Record<string, string>,
+  projectRootPath: string,
+): Promise<void> {
+  const body = await readBody(req);
+  let parsed: any;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    res.writeHead(400, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Invalid JSON' }));
+    return;
+  }
+
+  const id = parsed.id ? String(parsed.id) : String(Date.now());
+  const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
+  const dir = getHistoryDir(projectRootPath);
+
+  try {
+    ensureHistoryDir(dir);
+
+    // 写入对话文件
+    const conversationData = {
+      messages,
+      context: parsed.context ?? null,
+      sessionId: parsed.sessionId ?? null,
+      provider: parsed.provider ?? null,
+      model: parsed.model ?? '',
+      revertedToolIds: Array.isArray(parsed.revertedToolIds) ? parsed.revertedToolIds : [],
+    };
+    fs.writeFileSync(
+      path.join(dir, `${id}.json`),
+      JSON.stringify(conversationData, null, 2),
+      'utf-8',
+    );
+
+    // 更新 index
+    const index = readIndex(dir);
+    const now = Date.now();
+    index[id] = {
+      id,
+      title: extractTitle(messages),
+      createdAt: index[id]?.createdAt || now,
+      updatedAt: now,
+      provider: parsed.provider ?? null,
+      messageCount: messages.length,
+    };
+    writeIndex(dir, index);
+
+    res.writeHead(200, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ id, success: true }));
+  } catch {
+    res.writeHead(500, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'write_error' }));
+  }
+}
+
+/**
+ * 加载对话
+ */
+export async function handleAIHistoryLoadRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  corsHeaders: Record<string, string>,
+  projectRootPath: string,
+): Promise<void> {
+  const body = await readBody(req);
+  let parsed: any;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    res.writeHead(400, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Invalid JSON' }));
+    return;
+  }
+
+  const id = String(parsed.id || '');
+  if (!id) {
+    res.writeHead(400, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'missing_id' }));
+    return;
+  }
+
+  const dir = getHistoryDir(projectRootPath);
+  const filePath = path.join(dir, `${id}.json`);
+
+  try {
+    if (!fs.existsSync(filePath)) {
+      res.writeHead(200, { ...corsHeaders, 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not_found' }));
+      return;
+    }
+    const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    res.writeHead(200, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(data));
+  } catch {
+    res.writeHead(500, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'read_error' }));
+  }
+}
+
+/**
+ * 删除对话
+ */
+export async function handleAIHistoryDeleteRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  corsHeaders: Record<string, string>,
+  projectRootPath: string,
+): Promise<void> {
+  const body = await readBody(req);
+  let parsed: any;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    res.writeHead(400, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Invalid JSON' }));
+    return;
+  }
+
+  const id = String(parsed.id || '');
+  if (!id) {
+    res.writeHead(400, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'missing_id' }));
+    return;
+  }
+
+  const dir = getHistoryDir(projectRootPath);
+
+  try {
+    // 删除对话文件
+    const filePath = path.join(dir, `${id}.json`);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+
+    // 更新 index
+    const index = readIndex(dir);
+    delete index[id];
+    writeIndex(dir, index);
+
+    res.writeHead(200, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ success: true }));
+  } catch {
+    res.writeHead(500, { ...corsHeaders, 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'delete_error' }));
+  }
+}

--- a/packages/core/src/server/ai.ts
+++ b/packages/core/src/server/ai.ts
@@ -95,6 +95,15 @@ export function getAIOptions(
   return Object.keys(resolved).length > 0 ? resolved : undefined;
 }
 
+/**
+ * 从 behavior 配置中提取 expireDays
+ */
+export function getExpireDays(
+  behavior?: { ai?: { expireDays?: number } }
+): number {
+  return behavior?.ai?.expireDays ?? 0;
+}
+
 function normalizeAIProviderType(provider?: string | null): AIProviderType | undefined {
   if (provider === 'codex' || provider === 'claudeCode' || provider === 'opencode') {
     return provider;

--- a/packages/core/src/server/server.ts
+++ b/packages/core/src/server/server.ts
@@ -11,7 +11,13 @@ import { launchIDE } from 'launch-ide';
 import { DefaultPort } from '../shared/constant';
 import { getIP, getProjectRecord, setProjectRecord, findPort } from '../shared';
 import type { CodeOptions, RecordInfo } from '../shared';
-import { handleAIRequest, getAIOptions, handleAIModelRequest, handleAIRevertRequest } from './ai';
+import { handleAIRequest, getAIOptions, handleAIModelRequest, handleAIRevertRequest, getExpireDays } from './ai';
+import {
+  handleAIHistoryListRequest,
+  handleAIHistorySaveRequest,
+  handleAIHistoryLoadRequest,
+  handleAIHistoryDeleteRequest,
+} from './ai-history';
 import { getEnvVariables } from 'launch-ide';
 
 /**
@@ -156,6 +162,28 @@ export function createServer(
     // 处理 /ai/revert 路由
     if (pathname === '/ai/revert' && req.method === 'POST') {
       await handleAIRevertRequest(req, res, CORS_HEADERS, ProjectRootPath);
+      return;
+    }
+
+    // 处理 /ai/history 路由
+    if (pathname === '/ai/history' && req.method === 'GET') {
+      const expireDays = getExpireDays(options?.behavior);
+      await handleAIHistoryListRequest(res, CORS_HEADERS, ProjectRootPath, expireDays);
+      return;
+    }
+
+    if (pathname === '/ai/history/save' && req.method === 'POST') {
+      await handleAIHistorySaveRequest(req, res, CORS_HEADERS, ProjectRootPath);
+      return;
+    }
+
+    if (pathname === '/ai/history/load' && req.method === 'POST') {
+      await handleAIHistoryLoadRequest(req, res, CORS_HEADERS, ProjectRootPath);
+      return;
+    }
+
+    if (pathname === '/ai/history/delete' && req.method === 'POST') {
+      await handleAIHistoryDeleteRequest(req, res, CORS_HEADERS, ProjectRootPath);
       return;
     }
 

--- a/packages/core/src/shared/type.ts
+++ b/packages/core/src/shared/type.ts
@@ -274,6 +274,8 @@ export type Behavior = {
     claudeCode?: boolean | ClaudeCodeOptions;
     codex?: boolean | CodexOptions;
     opencode?: boolean | OpenCodeOptions;
+    /** 对话历史过期天数，默认 0 不自动清理 */
+    expireDays?: number;
   };
   defaultAction?: 'copy' | 'locate' | 'target' | 'ai';
 };

--- a/packages/core/types/client/ai-persist.d.ts
+++ b/packages/core/types/client/ai-persist.d.ts
@@ -21,6 +21,7 @@ export interface PersistedAIState {
     } | null;
     turnStatus: 'idle' | 'running' | 'done' | 'interrupt';
     revertedToolIds?: string[];
+    conversationId?: string | null;
 }
 /**
  * 保存 AI 状态到 sessionStorage

--- a/packages/core/types/client/ai.d.ts
+++ b/packages/core/types/client/ai.d.ts
@@ -68,6 +68,28 @@ export interface AIModelInfo {
     providers: ChatProvider[];
 }
 /**
+ * 对话历史条目
+ */
+export interface HistoryEntry {
+    id: string;
+    title: string;
+    createdAt: number;
+    updatedAt: number;
+    provider: string | null;
+    messageCount: number;
+}
+/**
+ * 完整对话数据
+ */
+export interface ConversationData {
+    messages: ChatMessage[];
+    context: ChatContext | null;
+    sessionId: string | null;
+    provider: ChatProvider | null;
+    model: string;
+    revertedToolIds: string[];
+}
+/**
  * 聊天状态接口
  */
 export interface ChatState {
@@ -92,6 +114,10 @@ export interface ChatState {
     showModelMenu: boolean;
     revertedToolIds: Set<string>;
     revertingToolIds: Set<string>;
+    conversationId: string | null;
+    showHistoryPanel: boolean;
+    historyList: HistoryEntry[];
+    historyLoading: boolean;
 }
 /**
  * 聊天功能处理器接口
@@ -120,6 +146,10 @@ export interface ChatHandlers {
     handleOverlayClick: () => void;
     revertEdit: (tool: ToolCall) => void;
     revertAllEdits: () => void;
+    toggleHistoryPanel: () => void;
+    loadConversation: (id: string) => void;
+    deleteConversation: (id: string) => void;
+    startNewConversation: () => void;
 }
 /**
  * 更新聊天框位置（使用 floating-ui）
@@ -225,6 +255,33 @@ export declare function revertEdit(ip: string, port: number, edits: Array<{
     old_string: string;
     new_string: string;
 }>): Promise<RevertResult[]>;
+/**
+ * 获取对话历史列表
+ */
+export declare function fetchHistoryList(ip: string, port: number): Promise<HistoryEntry[]>;
+/**
+ * 保存对话到服务端
+ */
+export declare function saveConversation(ip: string, port: number, data: {
+    id?: string | null;
+    messages: ChatMessage[];
+    context: ChatContext | null;
+    sessionId: string | null;
+    provider: ChatProvider | null;
+    model: string;
+    revertedToolIds: string[];
+}): Promise<{
+    id: string;
+    success: boolean;
+}>;
+/**
+ * 加载对话历史
+ */
+export declare function loadConversationData(ip: string, port: number, id: string): Promise<ConversationData | null>;
+/**
+ * 删除对话历史
+ */
+export declare function deleteConversationData(ip: string, port: number, id: string): Promise<boolean>;
 /**
  * 发送聊天消息到服务器
  */

--- a/packages/core/types/client/index.d.ts
+++ b/packages/core/types/client/index.d.ts
@@ -1,5 +1,5 @@
 import { LitElement, TemplateResult } from 'lit';
-import { ChatMessage, ChatContext, ChatImageAttachment, ChatProvider, ToolCall } from './ai';
+import { ChatMessage, ChatContext, ChatImageAttachment, ChatProvider, ToolCall, HistoryEntry } from './ai';
 interface Position {
     left?: string;
     right?: string;
@@ -129,6 +129,10 @@ export declare class CodeInspectorComponent extends LitElement {
     showModelMenu: boolean;
     revertedToolIds: Set<string>;
     revertingToolIds: Set<string>;
+    conversationId: string | null;
+    showHistoryPanel: boolean;
+    historyList: HistoryEntry[];
+    historyLoading: boolean;
     private chatAbortController;
     private turnTimerInterval;
     private turnStartTime;
@@ -260,10 +264,15 @@ export declare class CodeInspectorComponent extends LitElement {
     private scrollChatToBottom;
     private startTurnTimer;
     private stopTurnTimer;
+    private autoSaveConversation;
     interruptChat: () => void;
     handleRevertEdit: (tool: ToolCall) => Promise<void>;
     private extractRevertEdits;
     handleRevertAllEdits: () => Promise<void>;
+    toggleHistoryPanel: () => Promise<void>;
+    handleLoadConversation: (id: string) => Promise<void>;
+    handleDeleteConversation: (id: string) => Promise<void>;
+    handleStartNewConversation: () => void;
     handleChatDragStart: (e: MouseEvent) => void;
     handleChatDragMove: (e: MouseEvent) => void;
     handleChatDragEnd: () => void;

--- a/packages/core/types/server/ai-history.d.ts
+++ b/packages/core/types/server/ai-history.d.ts
@@ -1,0 +1,26 @@
+/// <reference types="node" />
+import http from 'http';
+export interface HistoryEntry {
+    id: string;
+    title: string;
+    createdAt: number;
+    updatedAt: number;
+    provider: string | null;
+    messageCount: number;
+}
+/**
+ * 获取对话历史列表
+ */
+export declare function handleAIHistoryListRequest(res: http.ServerResponse, corsHeaders: Record<string, string>, projectRootPath: string, expireDays: number): Promise<void>;
+/**
+ * 保存对话
+ */
+export declare function handleAIHistorySaveRequest(req: http.IncomingMessage, res: http.ServerResponse, corsHeaders: Record<string, string>, projectRootPath: string): Promise<void>;
+/**
+ * 加载对话
+ */
+export declare function handleAIHistoryLoadRequest(req: http.IncomingMessage, res: http.ServerResponse, corsHeaders: Record<string, string>, projectRootPath: string): Promise<void>;
+/**
+ * 删除对话
+ */
+export declare function handleAIHistoryDeleteRequest(req: http.IncomingMessage, res: http.ServerResponse, corsHeaders: Record<string, string>, projectRootPath: string): Promise<void>;

--- a/packages/core/types/server/ai.d.ts
+++ b/packages/core/types/server/ai.d.ts
@@ -53,6 +53,14 @@ export declare function getAIOptions(behavior?: {
         opencode?: boolean | OpenCodeOptions;
     };
 }): ResolvedAIOptions | undefined;
+/**
+ * 从 behavior 配置中提取 expireDays
+ */
+export declare function getExpireDays(behavior?: {
+    ai?: {
+        expireDays?: number;
+    };
+}): number;
 export declare function getAvailableAIProviders(aiOptions?: ResolvedAIOptions): AIProviderType[];
 export declare function resolveAIOptions(aiOptions: ResolvedAIOptions | undefined, requestedProvider?: AIProviderType): ActiveAIOptions | undefined;
 /**

--- a/packages/core/types/shared/type.d.ts
+++ b/packages/core/types/shared/type.d.ts
@@ -254,6 +254,8 @@ export type Behavior = {
         claudeCode?: boolean | ClaudeCodeOptions;
         codex?: boolean | CodexOptions;
         opencode?: boolean | OpenCodeOptions;
+        /** 对话历史过期天数，默认 0 不自动清理 */
+        expireDays?: number;
     };
     defaultAction?: 'copy' | 'locate' | 'target' | 'ai';
 };


### PR DESCRIPTION
## Summary

  - Persist each AI Q&A as a separate JSON file under
  `node_modules/.code-inspector/`, with an index file (`history-index.json`)
  mapping timestamps to summaries
  - Add a history panel in the chat dialog (clock icon in header) to browse,
  restore, and delete past conversations
  - Add `behavior.ai.expireDays` option to automatically clean up history older
  than the specified number of days (default `0` = no cleanup)
  - Update `behavior` type definition in both zh/en advance docs and add
  "Conversation History" section in both zh/en AI docs

  ## Changes

  - **`packages/core/src/server/ai-history.ts`** (new): Server-side history CRUD
   — list, save, load, delete handlers with lazy expiration cleanup
  - **`packages/core/src/server/ai.ts`**: Export `getExpireDays()` helper
  - **`packages/core/src/server/server.ts`**: Register 4 history routes (`GET
  /ai/history`, `POST /ai/history/save|load|delete`)
  - **`packages/core/src/shared/type.ts`**: Add `expireDays?: number` to
  `Behavior.ai`
  - **`packages/core/src/client/ai.ts`**: Add `HistoryEntry`/`ConversationData`
  types, history API functions, history panel UI with styles
  - **`packages/core/src/client/index.ts`**: Add history state properties,
  handlers (`toggleHistoryPanel`, `loadConversation`, `deleteConversation`,
  `startNewConversation`), and auto-save on turn completion
  - **`packages/core/src/client/ai-persist.ts`**: Add `conversationId` to
  `PersistedAIState`
  - **`docs/{zh,en}/guide/feature/ai.md`**: Document conversation history
  feature and `expireDays`
  - **`docs/{zh,en}/api/advance.md`**: Add `ai` and `defaultAction` fields to
  `behavior` type definition

  ## Test plan

  - [x] Send a message → verify
  `node_modules/.code-inspector/history-index.json` and a timestamped JSON file
  are created
  - [x] Send a second message → verify a separate history file is created (one
  file per Q&A)
  - [x] Click the clock icon in chat header → verify history panel shows with
  correct titles and metadata
  - [x] Click a history entry → verify conversation context is restored
  - [ x Click delete on a history entry → verify file is removed and list
  updates
  - [x] Click "New" in history panel → verify state resets to empty conversation
  - [x] Set `expireDays: 1`, manually backdate a history entry's `createdAt` →
  reopen history panel → verify expired entry is cleaned up
  - [x] Refresh page → verify sessionStorage restore still works alongside
  server-side persistence