### PR TITLE
feat: show React component names in inspector tree, fix JSXMemberExpression & React 19 support

### DIFF
--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -76,6 +76,133 @@ function nextTick() {
   });
 }
 
+// --- React Fiber helpers (for component tree in context menu) ---
+
+type FiberSource = {
+  columnNumber?: number;
+  fileName: string;
+  lineNumber?: number;
+};
+
+type Fiber = {
+  _debugSource?: FiberSource;
+  _debugInfo?: FiberSource; // Injected by our jsx-dev-runtime patch for React 19
+  _debugOwner?: Fiber;
+  type: string | { displayName?: string; name?: string; render?: { name?: string } };
+  stateNode: any;
+  child?: Fiber;
+  sibling?: Fiber;
+  return?: Fiber;
+};
+
+function getReactFiber(element: Element): Fiber | undefined {
+  if ('__REACT_DEVTOOLS_GLOBAL_HOOK__' in window) {
+    const { renderers } = (window as any).__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    for (const renderer of renderers.values()) {
+      try {
+        const fiber = renderer.findFiberByHostInstance(element);
+        if (fiber) return fiber;
+      } catch {
+        // React may be mid-render
+      }
+    }
+  }
+  for (const key in element) {
+    if (key.startsWith('__reactFiber')) return (element as any)[key];
+  }
+  return undefined;
+}
+
+function resolveInnerComponentName(type: any, depth = 0): string {
+  if (!type || depth > 5) return '';
+  const name = type.displayName ?? type.name;
+  if (name && !name.includes('Unknown')) return name;
+  if (type.WrappedComponent) return resolveInnerComponentName(type.WrappedComponent, depth + 1);
+  if (type.type) return resolveInnerComponentName(type.type, depth + 1);
+  const renderName = type.render?.displayName ?? type.render?.name;
+  if (renderName && !renderName.includes('Unknown')) return renderName;
+  return '';
+}
+
+function getFiberComponentName(fiber: Fiber): string {
+  if (typeof fiber.type === 'string') return fiber.type;
+  const t = fiber.type as any;
+  let name = t?.displayName ?? t?.name;
+
+  if (name?.includes('(Unknown)')) {
+    const inner = resolveInnerComponentName(t);
+    if (inner) name = name.replace(/Unknown/g, inner);
+  }
+
+  return name
+    ?? t?.render?.displayName ?? t?.render?.name
+    ?? t?.type?.displayName ?? t?.type?.name
+    ?? 'Unknown';
+}
+
+function getFiberSource(fiber: Fiber): FiberSource | undefined {
+  return fiber._debugSource ?? fiber._debugInfo;
+}
+
+function findFirstDomNode(fiber: Fiber): HTMLElement | null {
+  const root = fiber;
+  let current: Fiber | undefined = fiber.child;
+  while (current) {
+    if (current.stateNode instanceof HTMLElement) return current.stateNode;
+    if (current.child) { current = current.child; continue; }
+    while (current && current !== root && !current.sibling) {
+      current = current.return;
+    }
+    if (!current || current === root) break;
+    current = current.sibling;
+  }
+  return null;
+}
+
+interface FiberLayer {
+  name: string;
+  path: string;
+  line: number;
+  column: number;
+  element: HTMLElement;
+}
+
+function isValidSourcePath(fileName: string): boolean {
+  if (!fileName) return false;
+  if (fileName.includes('node_modules')) return false;
+  return true;
+}
+
+function getLayersFromFiber(target: HTMLElement): FiberLayer[] {
+  const fiber = getReactFiber(target);
+  if (!fiber) return [];
+
+  const layers: FiberLayer[] = [];
+  let current: Fiber | undefined = fiber;
+
+  while (current) {
+    const source = getFiberSource(current);
+    if (source?.fileName && isValidSourcePath(source.fileName)) {
+      const name = getFiberComponentName(current);
+      if (name.includes('Unknown')) { current = current._debugOwner; continue; }
+      const domNode = (current.stateNode instanceof HTMLElement)
+        ? current.stateNode
+        : findFirstDomNode(current);
+
+      layers.push({
+        name,
+        path: source.fileName,
+        line: source.lineNumber ?? 1,
+        column: source.columnNumber ?? 1,
+        element: domNode || target,
+      });
+    }
+    current = current._debugOwner;
+  }
+
+  return layers;
+}
+
 export class CodeInspectorComponent extends LitElement {
   @property()
   hotKeys: string = 'shiftKey,altKey';
@@ -836,8 +963,15 @@ export class CodeInspectorComponent extends LitElement {
   };
 
   generateNodeTree = (nodePath: HTMLElement[]): TreeNode => {
-    let root: TreeNode;
+    // Try fiber-based tree first (shows React component names)
+    const target = nodePath[0];
+    if (target) {
+      const fiberTree = this.generateFiberNodeTree(target);
+      if (fiberTree) return fiberTree;
+    }
 
+    // Fallback: DOM-based tree using data-insp-path attributes
+    let root: TreeNode;
     let depth = 1;
     let preNode = null;
 
@@ -861,6 +995,37 @@ export class CodeInspectorComponent extends LitElement {
     }
 
     return root!;
+  };
+
+  generateFiberNodeTree = (target: HTMLElement): TreeNode | null => {
+    const layers = getLayersFromFiber(target);
+    if (layers.length === 0) return null;
+
+    let root: TreeNode | null = null;
+    let preNode: TreeNode | null = null;
+
+    // Layers are innermost-first, reverse for tree (outermost = root)
+    for (let i = layers.length - 1; i >= 0; i--) {
+      const layer = layers[i];
+      const node: TreeNode = {
+        name: layer.name,
+        path: layer.path,
+        line: layer.line,
+        column: layer.column,
+        children: [],
+        element: layer.element,
+        depth: (layers.length - i),
+      };
+
+      if (preNode) {
+        preNode.children.push(node);
+      } else {
+        root = node;
+      }
+      preNode = node;
+    }
+
+    return root;
   };
 
   // disabled 的元素及其子元素无法触发 click 事件

--- a/packages/core/src/server/transform/transform-jsx.ts
+++ b/packages/core/src/server/transform/transform-jsx.ts
@@ -21,7 +21,9 @@ function getJSXElementName(nameNode: any): string {
     return objectName ? `${objectName}.${propertyName}` : propertyName;
   }
   if (nameNode.type === 'JSXNamespacedName') {
-    return `${nameNode.namespace?.name || ''}:${nameNode.name?.name || ''}`;
+    // Use '.' instead of ':' to avoid breaking data-insp-path parsing
+    // which uses ':' as its delimiter (filePath:line:column:tagName)
+    return `${nameNode.namespace?.name || ''}.${nameNode.name?.name || ''}`;
   }
   return '';
 }

--- a/packages/core/src/server/transform/transform-jsx.ts
+++ b/packages/core/src/server/transform/transform-jsx.ts
@@ -10,6 +10,22 @@ import importMetaPlugin from '@babel/plugin-syntax-import-meta';
 // @ts-expect-error - @babel/plugin-proposal-decorators doesn't provide TypeScript types
 import proposalDecorators from '@babel/plugin-proposal-decorators';
 
+function getJSXElementName(nameNode: any): string {
+  if (!nameNode) return '';
+  if (nameNode.type === 'JSXIdentifier') {
+    return nameNode.name || '';
+  }
+  if (nameNode.type === 'JSXMemberExpression') {
+    const objectName = getJSXElementName(nameNode.object);
+    const propertyName = nameNode.property?.name || '';
+    return objectName ? `${objectName}.${propertyName}` : propertyName;
+  }
+  if (nameNode.type === 'JSXNamespacedName') {
+    return `${nameNode.namespace?.name || ''}:${nameNode.name?.name || ''}`;
+  }
+  return '';
+}
+
 export function transformJsx(content: string, filePath: string, escapeTags: EscapeTags) {
   const s = new MagicString(content);
 
@@ -27,7 +43,7 @@ export function transformJsx(content: string, filePath: string, escapeTags: Esca
 
   traverse(ast!, {
     enter({ node }: any) {
-      const nodeName = node?.openingElement?.name?.name || '';
+      const nodeName = getJSXElementName(node?.openingElement?.name);
       const attributes = node?.openingElement?.attributes || [];
       if (
         node.type === 'JSXElement' &&

--- a/packages/core/types/client/index.d.ts
+++ b/packages/core/types/client/index.d.ts
@@ -163,6 +163,7 @@ export declare class CodeInspectorComponent extends LitElement {
     handleMouseClick: (e: MouseEvent | TouchEvent) => void;
     handleContextMenu: (e: MouseEvent) => void;
     generateNodeTree: (nodePath: HTMLElement[]) => TreeNode;
+    generateFiberNodeTree: (target: HTMLElement) => TreeNode | null;
     handlePointerDown: (e: PointerEvent) => void;
     handleKeyUp: (e: KeyboardEvent) => void;
     printTip: () => void;

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -125,6 +125,17 @@ export function ViteCodeInspectorPlugin(options: Options) {
     apply(_, { command }) {
       return !options.close && isDev(options.dev, command === 'serve');
     },
+    config() {
+      // Exclude jsx-dev-runtime from Vite's dependency pre-bundling so the
+      // transform hook can intercept it by filename. Without this, Vite may
+      // bundle it into a chunk file (e.g. chunk-XXXXX.js) where the filename
+      // no longer contains "jsx-dev-runtime".
+      return {
+        optimizeDeps: {
+          exclude: ['react/jsx-dev-runtime'],
+        },
+      };
+    },
     configResolved(config) {
       record.envDir = config.envDir || config.root;
       record.root = config.root;
@@ -133,6 +144,18 @@ export function ViteCodeInspectorPlugin(options: Options) {
       // Patch React 19 jsx-dev-runtime to re-inject source into _debugInfo
       if (id.includes('jsx-dev-runtime') && id.includes('.js')) {
         return patchReact19JsxDevRuntime(code);
+      }
+
+      // Fallback: Vite may still pre-bundle jsx-dev-runtime into chunk files
+      // (e.g. when another dep re-exports it). Detect via code content,
+      // but only for files in Vite's dep cache to avoid scanning user code.
+      if (
+        id.includes('node_modules') &&
+        code.includes('"_debugInfo"') &&
+        code.includes('value: null')
+      ) {
+        const patched = patchReact19JsxDevRuntime(code);
+        if (patched) return patched;
       }
 
       if (isExcludedFile(id, options)) {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -13,6 +13,41 @@ import chalk from 'chalk';
 
 const PluginName = '@code-inspector/vite';
 
+// Patch React 19's jsx-dev-runtime to restore source info on fibers.
+// React 19 removed _debugSource (facebook/react#32574) but still receives `source`
+// in jsxDEV(). This patch injects it into _debugInfo so the client can read it.
+// Adapted from vite-plugin-react-click-to-component by ArnaudBarre.
+function patchReact19JsxDevRuntime(code: string): string | undefined {
+  if (code.includes('_source')) return undefined; // React <19, already has source
+
+  const defineIndex = code.indexOf('"_debugInfo"');
+  if (defineIndex === -1) return undefined;
+  const valueIndex = code.indexOf('value: null', defineIndex);
+  if (valueIndex === -1) return undefined;
+
+  let patched =
+    code.slice(0, valueIndex) + 'value: source' + code.slice(valueIndex + 11);
+
+  // React 19.0-19.1: source is already a param of ReactElement
+  if (patched.includes('function ReactElement(type, key, self, source,')) {
+    return patched;
+  }
+
+  // React 19.2+: source needs to be threaded through jsxDEV → jsxDEVImpl → ReactElement
+  patched = patched.replace(
+    /maybeKey,\s*isStaticChildren/g,
+    'maybeKey, isStaticChildren, source',
+  );
+  patched = patched.replace(
+    /(\w+)?,\s*debugStack,\s*debugTask/g,
+    (m: string, previousArg: string) => {
+      if (previousArg === 'source') return m;
+      return m.replace('debugTask', 'debugTask, source');
+    },
+  );
+  return patched;
+}
+
 const OrderedPlugins = [
   {
     name: 'vite:react-babel',
@@ -95,6 +130,11 @@ export function ViteCodeInspectorPlugin(options: Options) {
       record.root = config.root;
     },
     async transform(code: string, id: string) {
+      // Patch React 19 jsx-dev-runtime to re-inject source into _debugInfo
+      if (id.includes('jsx-dev-runtime') && id.includes('.js')) {
+        return patchReact19JsxDevRuntime(code);
+      }
+
       if (isExcludedFile(id, options)) {
         return code;
       }

--- a/packages/vite/types/index.d.ts
+++ b/packages/vite/types/index.d.ts
@@ -7,6 +7,11 @@ export declare function ViteCodeInspectorPlugin(options: Options): {
     apply(_: any, { command }: {
         command: any;
     }): boolean;
+    config(): {
+        optimizeDeps: {
+            exclude: string[];
+        };
+    };
     configResolved(config: any): void;
     transform(code: string, id: string): Promise<string>;
     transformIndexHtml(html: any): Promise<any>;

--- a/test/core/server/transform/transform-jsx.test.ts
+++ b/test/core/server/transform/transform-jsx.test.ts
@@ -302,6 +302,16 @@ function B() { return <span>B</span>; }`;
     });
   });
 
+  describe('JSXNamespacedName support', () => {
+    it('should use dot separator instead of colon to avoid breaking data-insp-path parsing', () => {
+      const content = 'function App() { return <svg:rect width="100" />; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(':svg.rect"');
+      expect(result).not.toContain(':svg:rect"');
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle elements without name (should not crash)', () => {
       // This tests that code handles nodeName being empty

--- a/test/core/server/transform/transform-jsx.test.ts
+++ b/test/core/server/transform/transform-jsx.test.ts
@@ -265,6 +265,43 @@ function B() { return <span>B</span>; }`;
     });
   });
 
+  describe('JSXMemberExpression support', () => {
+    it('should handle JSXMemberExpression like Typography.H2', () => {
+      const content = 'function App() { return <Typography.H2>Hello</Typography.H2>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(':Typography.H2"');
+    });
+
+    it('should handle JSXMemberExpression like Page.Content', () => {
+      const content = 'function App() { return <Page.Content>Hello</Page.Content>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(':Page.Content"');
+    });
+
+    it('should handle self-closing JSXMemberExpression', () => {
+      const content = 'function App() { return <Icons.Close />; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(':Icons.Close"');
+    });
+
+    it('should handle deeply nested member expressions', () => {
+      const content = 'function App() { return <A.B.C>Hello</A.B.C>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(':A.B.C"');
+    });
+
+    it('should escape JSXMemberExpression tags via escapeTags', () => {
+      const content = 'function App() { return <Foo.Bar>Hello</Foo.Bar>; }';
+      const result = transformJsx(content, filePath, ['Foo.Bar']);
+
+      expect(result).not.toContain(':Foo.Bar"');
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle elements without name (should not crash)', () => {
       // This tests that code handles nodeName being empty


### PR DESCRIPTION
## Summary

This PR improves the "Click node to locate" panel by showing **actual React component names** instead of just DOM tags, adds support for **JSXMemberExpression** in `data-insp-path`, and restores **React 19 compatibility** for source file resolution.

### Changes

#### 1. JSXMemberExpression support (`packages/core/src/server/transform/transform-jsx.ts`)

The Babel transform that injects `data-insp-path` previously only handled `JSXIdentifier` (simple tags like `<div>`, `<Button>`). JSXMemberExpression elements like `<Typography.H2>`, `<Page.Content>`, `<Icons.Close />` were silently dropped — `nodeName` resolved to an empty string and the element was skipped.

Added `getJSXElementName()` that recursively handles `JSXIdentifier`, `JSXMemberExpression`, and `JSXNamespacedName`. Includes 5 new test cases.

#### 2. React 19 jsx-dev-runtime patch (`packages/vite/src/index.ts`)

React 19 removed `_debugSource` from fiber nodes ([facebook/react#32574](https://github.com/facebook/react/issues/32574)), which broke source file resolution for tools that rely on it.

The Vite plugin now intercepts `jsx-dev-runtime.js` during dev and patches `_debugInfo` to carry the `source` parameter (fileName, lineNumber, columnNumber) that `jsxDEV()` still receives but React 19 no longer stores. Supports React 19.0–19.1 and 19.2+ (different internal signatures).

Adapted from [vite-plugin-react-click-to-component](https://github.com/ArnaudBarre/vite-plugin-react-click-to-component) by @ArnaudBarre.

#### 3. Vite pre-bundling compatibility (`packages/vite/src/index.ts`)

Vite pre-bundles dependencies into chunk files (e.g. `chunk-XXXXX.js`), so the `jsx-dev-runtime` code can end up in a chunk where the filename no longer contains "jsx-dev-runtime". This caused the React 19 patch to silently not apply in real-world Vite projects.

Fixed with two layers:
- **`optimizeDeps.exclude`**: Excludes `react/jsx-dev-runtime` from Vite's dependency pre-bundling so the transform hook can intercept it by filename
- **Content-based fallback**: For edge cases where jsx-dev-runtime still ends up in a chunk (e.g. re-exported by another dep), detects the `_debugInfo` property definition in code content for files under `node_modules`

#### 4. Fiber-based component tree (`packages/core/src/client/index.ts`)

The right-click context menu ("Click node to locate") now walks React's `_debugOwner` chain to build the component tree, showing actual component names like `<Dashboard>`, `<UserProfile>`, `<Card>` instead of just `<div>`, `<span>`, `<input>`.

- Uses React DevTools global hook or `__reactFiber` to get fibers from DOM elements
- Walks `_debugOwner` for the component hierarchy (naturally skips framework internals)
- Reads `_debugSource` (React <19) or `_debugInfo` (React 19, via our patch) for file paths
- Filters out components from `node_modules` or with unresolvable names
- Resolves HOC-wrapped component names (`React.memo`, `React.forwardRef`, `.WrappedComponent`)
- Falls back to the original DOM-based tree for non-React apps or when fibers aren't available

## Before / After

**Before** — tree shows mostly `<div>` tags:

<img width="782" height="452" alt="image" src="https://github.com/user-attachments/assets/4d47d3c3-a9e6-4963-8e29-b48002860648" />

**After** — tree shows actual React component hierarchy:

<img width="810" height="542" alt="image" src="https://github.com/user-attachments/assets/07c0401c-2dac-4978-a20f-467a3ce5ac19" />

## Testing

- Tested with React 18 (`demos/vite-react`) and React 19 (local demo)
- Tested with Vite 7 (pre-bundled chunk detection verified)
- All existing tests pass + 5 new tests for JSXMemberExpression
- Non-React apps fall back to existing DOM-based behavior (no regression)