### PR TITLE
fix: support dotted JSX tag names

### DIFF
--- a/packages/core/src/server/transform/transform-jsx.ts
+++ b/packages/core/src/server/transform/transform-jsx.ts
@@ -10,6 +10,40 @@ import importMetaPlugin from '@babel/plugin-syntax-import-meta';
 // @ts-expect-error - @babel/plugin-proposal-decorators doesn't provide TypeScript types
 import proposalDecorators from '@babel/plugin-proposal-decorators';
 
+function getJsxElementName(node: any): string {
+  if (!node) {
+    return '';
+  }
+
+  if (node.type === 'JSXIdentifier') {
+    return node.name || '';
+  }
+
+  if (node.type === 'JSXMemberExpression') {
+    const objectName = getJsxElementName(node.object);
+    const propertyName = getJsxElementName(node.property);
+
+    if (!objectName || !propertyName) {
+      return '';
+    }
+
+    return `${objectName}.${propertyName}`;
+  }
+
+  if (node.type === 'JSXNamespacedName') {
+    const namespaceName = getJsxElementName(node.namespace);
+    const localName = getJsxElementName(node.name);
+
+    if (!namespaceName || !localName) {
+      return '';
+    }
+
+    return `${namespaceName}:${localName}`;
+  }
+
+  return '';
+}
+
 export function transformJsx(content: string, filePath: string, escapeTags: EscapeTags) {
   const s = new MagicString(content);
 
@@ -27,7 +61,7 @@ export function transformJsx(content: string, filePath: string, escapeTags: Esca
 
   traverse(ast!, {
     enter({ node }: any) {
-      const nodeName = node?.openingElement?.name?.name || '';
+      const nodeName = getJsxElementName(node?.openingElement?.name);
       const attributes = node?.openingElement?.attributes || [];
       if (
         node.type === 'JSXElement' &&

--- a/test/core/server/transform/transform-jsx.test.ts
+++ b/test/core/server/transform/transform-jsx.test.ts
@@ -254,6 +254,21 @@ class MyComponent {
       expect(result).toContain(`:div"`);
     });
 
+    it('should handle JSX member expression tag names', () => {
+      const content = 'function App() { return <Form.Item><input /></Form.Item>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`${filePath}:1:25:Form.Item"`);
+      expect(result).toContain(':input"');
+    });
+
+    it('should handle JSX namespaced tag names', () => {
+      const content = 'function App() { return <svg:path />; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`${filePath}:1:25:svg:path"`);
+    });
+
     it('should handle multiple root elements in different functions', () => {
       const content = `
 function A() { return <div>A</div>; }


### PR DESCRIPTION
This updates JSX element name extraction so member expressions like Form.Item and namespaced names like svg:path are serialized before metadata injection. It also adds transform coverage for both tag-name shapes to prevent regressions. Validation was done with the focused transform JSX Vitest suite.

Fixes #507