### PR TITLE
feat(core): propagate inspection paths through React component roots

### DIFF
--- a/packages/core/src/server/transform/transform-jsx.ts
+++ b/packages/core/src/server/transform/transform-jsx.ts
@@ -10,6 +10,12 @@ import importMetaPlugin from '@babel/plugin-syntax-import-meta';
 // @ts-expect-error - @babel/plugin-proposal-decorators doesn't provide TypeScript types
 import proposalDecorators from '@babel/plugin-proposal-decorators';
 
+const PropagatedPathBinding = '__codeInspectorPath';
+const ImplicitPropsBinding = '__codeInspectorProps';
+type RootTarget =
+  | { type: 'jsx'; node: any }
+  | { type: 'createElement'; node: any };
+
 export function transformJsx(
   content: string,
   filePath: string,
@@ -29,37 +35,897 @@ export function transformJsx(
     ],
   });
 
+  const dynamicInjectedElements = new Set<number>();
+  const dynamicInjectedCreateElementCalls = new Set<number>();
+
   traverse(ast!, {
+    FunctionDeclaration(path: any) {
+      transformComponentFunction(
+        path,
+        s,
+        content,
+        filePath,
+        dynamicInjectedElements,
+        dynamicInjectedCreateElementCalls,
+        escapeTags,
+      );
+    },
+    FunctionExpression(path: any) {
+      transformComponentFunction(
+        path,
+        s,
+        content,
+        filePath,
+        dynamicInjectedElements,
+        dynamicInjectedCreateElementCalls,
+        escapeTags,
+      );
+    },
+    ArrowFunctionExpression(path: any) {
+      transformComponentFunction(
+        path,
+        s,
+        content,
+        filePath,
+        dynamicInjectedElements,
+        dynamicInjectedCreateElementCalls,
+        escapeTags,
+      );
+    },
+    ClassDeclaration(path: any) {
+      transformClassComponent(
+        path,
+        s,
+        content,
+        filePath,
+        dynamicInjectedElements,
+        dynamicInjectedCreateElementCalls,
+        escapeTags,
+      );
+    },
+    ClassExpression(path: any) {
+      transformClassComponent(
+        path,
+        s,
+        content,
+        filePath,
+        dynamicInjectedElements,
+        dynamicInjectedCreateElementCalls,
+        escapeTags,
+      );
+    },
     enter({ node }: any) {
-      const nodeName = node.openingElement?.name?.name || '';
-      const attributes = node.openingElement?.attributes || [];
+      const openingElement = node.openingElement;
+      const nodeName = getJsxNodeName(openingElement?.name);
+      const attributes = openingElement?.attributes || [];
       if (
         node.type === 'JSXElement' &&
         nodeName &&
-        !isEscapeTags(escapeTags, nodeName)
+        !isEscapedJsxTag(escapeTags, nodeName)
       ) {
         if (
-          attributes.some(
-            (attr: any) =>
-              attr.type !== 'JSXSpreadAttribute' &&
-              attr.name?.name === PathName,
-          )
+          dynamicInjectedElements.has(openingElement.start) ||
+          hasPathAttribute(attributes)
         ) {
           return;
         }
 
         // 向 dom 上添加一个带有 filepath/row/column 的属性
         const insertPosition =
-          node.openingElement.end - (node.openingElement.selfClosing ? 2 : 1);
-        const { line, column } = node.loc.start;
-        const addition = ` ${PathName}="${filePath}:${line}:${
-          column + 1
-        }:${nodeName}"${node.openingElement.attributes.length ? ' ' : ''}`;
+          openingElement.end - (openingElement.selfClosing ? 2 : 1);
+        const addition = ` ${PathName}=${JSON.stringify(
+          getNodePathValue(filePath, node, nodeName),
+        )}${openingElement.attributes.length ? ' ' : ''}`;
 
         s.prependLeft(insertPosition, addition);
+        return;
+      }
+
+      if (node.type === 'CallExpression') {
+        injectStaticCreateElementPath(
+          node,
+          s,
+          content,
+          filePath,
+          dynamicInjectedCreateElementCalls,
+          escapeTags,
+        );
       }
     },
   });
 
   return s.toString();
 }
+
+function transformComponentFunction(
+  path: any,
+  s: MagicString,
+  content: string,
+  filePath: string,
+  dynamicInjectedElements: Set<number>,
+  dynamicInjectedCreateElementCalls: Set<number>,
+  escapeTags: EscapeTags,
+) {
+  if (!isComponentFunction(path)) {
+    return;
+  }
+
+  // React 不会像 Vue 一样把组件调用点上的 attrs 自动透传到根 DOM，
+  // 这里改写组件根节点，让它优先读取 props[data-insp-path]。
+  const propExpression = getPropagatedPathExpression(path, s, content);
+  if (!propExpression) {
+    return;
+  }
+
+  const injectRootExpression = (expression: any, scope: any) => {
+    injectRootTargets(
+      collectRootTargets(expression, scope),
+      s,
+      content,
+      filePath,
+      dynamicInjectedElements,
+      dynamicInjectedCreateElementCalls,
+      propExpression,
+      escapeTags,
+    );
+  };
+
+  if (path.node.body?.type !== 'BlockStatement') {
+    injectRootExpression(path.node.body, path.scope);
+    return;
+  }
+
+  path.traverse({
+    Function(innerPath: any) {
+      if (innerPath.node !== path.node) {
+        innerPath.skip();
+      }
+    },
+    Class(innerPath: any) {
+      innerPath.skip();
+    },
+    ReturnStatement(returnPath: any) {
+      injectRootExpression(returnPath.node.argument, returnPath.scope);
+    },
+  });
+}
+
+function isComponentFunction(path: any) {
+  const functionOwnerName = getComponentOwnerName(path);
+  if (functionOwnerName) {
+    return /^[A-Z]/.test(functionOwnerName);
+  }
+
+  return hasExportDefaultAncestor(path) && containsRenderableReturn(path);
+}
+
+function transformClassComponent(
+  path: any,
+  s: MagicString,
+  content: string,
+  filePath: string,
+  dynamicInjectedElements: Set<number>,
+  dynamicInjectedCreateElementCalls: Set<number>,
+  escapeTags: EscapeTags,
+) {
+  if (!isComponentClass(path)) {
+    return;
+  }
+
+  const renderMethodPaths = getRenderMethodPaths(path);
+  const propExpression = `this.props && this.props[${JSON.stringify(PathName)}]`;
+  const injectRootExpression = (expression: any, scope: any) => {
+    injectRootTargets(
+      collectRootTargets(expression, scope),
+      s,
+      content,
+      filePath,
+      dynamicInjectedElements,
+      dynamicInjectedCreateElementCalls,
+      propExpression,
+      escapeTags,
+    );
+  };
+
+  for (const renderMethodPath of renderMethodPaths) {
+    renderMethodPath.traverse({
+      Function(innerPath: any) {
+        if (innerPath.node !== renderMethodPath.node) {
+          innerPath.skip();
+        }
+      },
+      Class(innerPath: any) {
+        innerPath.skip();
+      },
+      ReturnStatement(returnPath: any) {
+        injectRootExpression(returnPath.node.argument, returnPath.scope);
+      },
+    });
+  }
+}
+
+function isComponentClass(path: any) {
+  const renderMethodPaths = getRenderMethodPaths(path);
+  if (!path.node.superClass || renderMethodPaths.length === 0) {
+    return false;
+  }
+
+  const classOwnerName = getComponentOwnerName(path);
+  if (classOwnerName) {
+    return /^[A-Z]/.test(classOwnerName);
+  }
+
+  return (
+    hasExportDefaultAncestor(path) &&
+    renderMethodPaths.some((renderMethodPath: any) =>
+      containsMethodRenderableReturn(renderMethodPath),
+    )
+  );
+}
+
+function getComponentOwnerName(path: any) {
+  if (path.node.id?.type === 'Identifier') {
+    return path.node.id.name;
+  }
+
+  let currentPath = path.parentPath;
+  while (currentPath) {
+    if (
+      currentPath.isVariableDeclarator?.() &&
+      currentPath.node.id?.type === 'Identifier'
+    ) {
+      return currentPath.node.id.name;
+    }
+
+    if (
+      currentPath.isAssignmentExpression?.() &&
+      currentPath.node.left?.type === 'Identifier'
+    ) {
+      return currentPath.node.left.name;
+    }
+
+    if (
+      currentPath.isClass?.() ||
+      currentPath.isFunction?.() ||
+      currentPath.isObjectMethod?.()
+    ) {
+      break;
+    }
+
+    currentPath = currentPath.parentPath;
+  }
+
+  return '';
+}
+
+function hasExportDefaultAncestor(path: any) {
+  let currentPath = path.parentPath;
+  while (currentPath) {
+    if (currentPath.isExportDefaultDeclaration?.()) {
+      return true;
+    }
+
+    if (
+      currentPath.isClass?.() ||
+      currentPath.isFunction?.() ||
+      currentPath.isObjectMethod?.()
+    ) {
+      return false;
+    }
+
+    currentPath = currentPath.parentPath;
+  }
+
+  return false;
+}
+
+function containsRenderableReturn(path: any): boolean {
+  let hasRenderableReturn = false;
+  const injectibleBody = path.node.body;
+  if (injectibleBody?.type !== 'BlockStatement') {
+    return collectRootTargets(injectibleBody, path.scope).length > 0;
+  }
+
+  path.traverse({
+    Function(innerPath: any) {
+      if (innerPath.node !== path.node) {
+        innerPath.skip();
+      }
+    },
+    Class(innerPath: any) {
+      innerPath.skip();
+    },
+    ReturnStatement(returnPath: any) {
+      if (
+        collectRootTargets(returnPath.node.argument, returnPath.scope).length >
+        0
+      ) {
+        hasRenderableReturn = true;
+        returnPath.stop();
+      }
+    },
+  });
+
+  return hasRenderableReturn;
+}
+
+function getRenderMethodPaths(path: any) {
+  return path
+    .get('body.body')
+    .filter(
+      (memberPath: any) =>
+        memberPath.node?.type === 'ClassMethod' &&
+        getObjectPropertyName(memberPath.node.key) === 'render',
+    );
+}
+
+function containsMethodRenderableReturn(path: any): boolean {
+  let hasRenderableReturn = false;
+
+  path.traverse({
+    Function(innerPath: any) {
+      if (innerPath.node !== path.node) {
+        innerPath.skip();
+      }
+    },
+    Class(innerPath: any) {
+      innerPath.skip();
+    },
+    ReturnStatement(returnPath: any) {
+      if (
+        collectRootTargets(returnPath.node.argument, returnPath.scope).length >
+        0
+      ) {
+        hasRenderableReturn = true;
+        returnPath.stop();
+      }
+    },
+  });
+
+  return hasRenderableReturn;
+}
+
+function getPropagatedPathExpression(
+  path: any,
+  s: MagicString,
+  content: string,
+) {
+  const firstParam = path.node.params?.[0];
+  if (!firstParam) {
+    // 无参组件需要补一个隐式 props 形参，才能读取调用点传进来的路径。
+    const insertPosition = getEmptyParamsInsertPosition(path.node, content);
+    if (insertPosition == null) {
+      return '';
+    }
+    s.prependLeft(insertPosition, ImplicitPropsBinding);
+    return `${ImplicitPropsBinding} && ${ImplicitPropsBinding}[${JSON.stringify(PathName)}]`;
+  }
+
+  return getParameterPathExpression(firstParam, s);
+}
+
+function getParameterPathExpression(param: any, s: MagicString): string {
+  if (param.type === 'Identifier') {
+    return `${param.name} && ${param.name}[${JSON.stringify(PathName)}]`;
+  }
+
+  if (param.type === 'AssignmentPattern') {
+    return getParameterPathExpression(param.left, s);
+  }
+
+  if (param.type === 'ObjectPattern') {
+    const existingBinding = getObjectPatternPathBinding(param);
+    if (existingBinding) {
+      return existingBinding;
+    }
+
+    // 解构 props 时补出 data-insp-path，尽量不改变用户原有写法。
+    s.prependLeft(
+      param.start + 1,
+      `${JSON.stringify(PathName)}: ${PropagatedPathBinding}${
+        param.properties.length ? ', ' : ''
+      }`,
+    );
+    return PropagatedPathBinding;
+  }
+
+  return '';
+}
+
+function getObjectPatternPathBinding(param: any): string {
+  for (const property of param.properties || []) {
+    if (
+      property?.type === 'ObjectProperty' &&
+      getObjectPropertyName(property.key) === PathName
+    ) {
+      if (property.value?.type === 'Identifier') {
+        return property.value.name;
+      }
+
+      if (
+        property.value?.type === 'AssignmentPattern' &&
+        property.value.left?.type === 'Identifier'
+      ) {
+        return property.value.left.name;
+      }
+    }
+  }
+
+  return '';
+}
+
+function getObjectPropertyName(node: any): string {
+  if (!node) {
+    return '';
+  }
+
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+
+  if (node.type === 'StringLiteral') {
+    return node.value;
+  }
+
+  return '';
+}
+
+function getEmptyParamsInsertPosition(node: any, content: string) {
+  const bodyStart = node.body?.start;
+  if (typeof node.start !== 'number' || typeof bodyStart !== 'number') {
+    return null;
+  }
+
+  const header = content.slice(node.start, bodyStart);
+  const closeParenOffset = header.lastIndexOf(')');
+  if (closeParenOffset === -1) {
+    return null;
+  }
+
+  return node.start + closeParenOffset;
+}
+
+function injectRootTargets(
+  rootTargets: RootTarget[],
+  s: MagicString,
+  content: string,
+  filePath: string,
+  dynamicInjectedElements: Set<number>,
+  dynamicInjectedCreateElementCalls: Set<number>,
+  propExpression: string,
+  escapeTags: EscapeTags,
+) {
+  for (const rootTarget of rootTargets) {
+    if (rootTarget.type === 'jsx') {
+      injectDynamicPathAttribute(
+        rootTarget.node,
+        s,
+        filePath,
+        dynamicInjectedElements,
+        propExpression,
+        escapeTags,
+      );
+      continue;
+    }
+
+    injectDynamicCreateElementPath(
+      rootTarget.node,
+      s,
+      content,
+      filePath,
+      dynamicInjectedCreateElementCalls,
+      propExpression,
+      escapeTags,
+    );
+  }
+}
+
+function collectRootTargets(
+  node: any,
+  scope: any,
+  visitedBindings = new Set<string>(),
+): RootTarget[] {
+  if (!node) {
+    return [];
+  }
+
+  const unwrappedNode = unwrapRenderableExpression(node);
+  if (unwrappedNode !== node) {
+    return collectRootTargets(unwrappedNode, scope, visitedBindings);
+  }
+
+  if (unwrappedNode.type === 'JSXElement') {
+    return [{ type: 'jsx', node: unwrappedNode }];
+  }
+
+  if (unwrappedNode.type === 'CallExpression') {
+    if (isCreatePortalCall(unwrappedNode)) {
+      return collectRootTargets(
+        unwrappedNode.arguments?.[0],
+        scope,
+        visitedBindings,
+      );
+    }
+
+    if (isCreateElementCall(unwrappedNode)) {
+      return [{ type: 'createElement', node: unwrappedNode }];
+    }
+  }
+
+  if (unwrappedNode.type === 'Identifier') {
+    return collectIdentifierRootTargets(unwrappedNode, scope, visitedBindings);
+  }
+
+  if (unwrappedNode.type === 'ConditionalExpression') {
+    return [
+      ...collectRootTargets(unwrappedNode.consequent, scope, visitedBindings),
+      ...collectRootTargets(unwrappedNode.alternate, scope, visitedBindings),
+    ];
+  }
+
+  if (unwrappedNode.type === 'LogicalExpression') {
+    return [
+      ...collectRootTargets(unwrappedNode.left, scope, visitedBindings),
+      ...collectRootTargets(unwrappedNode.right, scope, visitedBindings),
+    ];
+  }
+
+  if (unwrappedNode.type === 'SequenceExpression') {
+    return collectRootTargets(
+      unwrappedNode.expressions[unwrappedNode.expressions.length - 1],
+      scope,
+      visitedBindings,
+    );
+  }
+
+  if (unwrappedNode.type === 'ArrayExpression') {
+    return unwrappedNode.elements.flatMap((element: any) => {
+      if (!element) {
+        return [];
+      }
+
+      if (element.type === 'SpreadElement') {
+        return collectRootTargets(element.argument, scope, visitedBindings);
+      }
+
+      return collectRootTargets(element, scope, visitedBindings);
+    });
+  }
+
+  if (unwrappedNode.type === 'JSXFragment') {
+    // Fragment 本身不会落到 DOM，上层路径需要下发给它的直接根子节点。
+    return unwrappedNode.children.flatMap((child: any) => {
+      if (child.type === 'JSXElement') {
+        return [{ type: 'jsx', node: child }];
+      }
+      if (child.type === 'JSXFragment') {
+        return collectRootTargets(child, scope, visitedBindings);
+      }
+      if (child.type === 'JSXExpressionContainer') {
+        return collectRootTargets(child.expression, scope, visitedBindings);
+      }
+      return [];
+    });
+  }
+
+  return [];
+}
+
+function unwrapRenderableExpression(node: any) {
+  if (
+    node?.type === 'ParenthesizedExpression' ||
+    node?.type === 'TSAsExpression' ||
+    node?.type === 'TSTypeAssertion' ||
+    node?.type === 'TSNonNullExpression' ||
+    node?.type === 'TypeCastExpression'
+  ) {
+    return node.expression;
+  }
+
+  return node;
+}
+
+function collectIdentifierRootTargets(
+  node: any,
+  scope: any,
+  visitedBindings: Set<string>,
+) {
+  if (!scope || node.name === 'undefined') {
+    return [];
+  }
+
+  const binding = scope.getBinding?.(node.name);
+  if (!binding) {
+    return [];
+  }
+
+  const bindingKey = `${binding.identifier?.start ?? ''}:${binding.identifier?.name ?? ''}`;
+  if (visitedBindings.has(bindingKey)) {
+    return [];
+  }
+  visitedBindings.add(bindingKey);
+
+  if (binding.path?.node?.type === 'VariableDeclarator') {
+    if (binding.path.node.init) {
+      return collectRootTargets(
+        binding.path.node.init,
+        binding.path.scope,
+        visitedBindings,
+      );
+    }
+
+    const assignmentRightNode = getSingleBindingAssignment(binding);
+    if (assignmentRightNode) {
+      return collectRootTargets(
+        assignmentRightNode,
+        binding.path.scope,
+        visitedBindings,
+      );
+    }
+  }
+
+  return [];
+}
+
+function getSingleBindingAssignment(binding: any) {
+  const assignmentPaths = (binding.constantViolations || []).filter(
+    (violationPath: any) =>
+      violationPath.isAssignmentExpression?.() &&
+      violationPath.node.left?.type === 'Identifier' &&
+      violationPath.node.left.name === binding.identifier?.name,
+  );
+
+  if (assignmentPaths.length !== 1) {
+    return null;
+  }
+
+  return assignmentPaths[0].node.right;
+}
+
+function injectDynamicPathAttribute(
+  node: any,
+  s: MagicString,
+  filePath: string,
+  dynamicInjectedElements: Set<number>,
+  propExpression: string,
+  escapeTags: EscapeTags,
+) {
+  const openingElement = node?.openingElement;
+  const nodeName = getJsxNodeName(openingElement?.name);
+  if (
+    !openingElement ||
+    !nodeName ||
+    isEscapedJsxTag(escapeTags, nodeName) ||
+    hasPathAttribute(openingElement.attributes)
+  ) {
+    return;
+  }
+
+  // 组件根节点优先显示调用点路径；没有调用点信息时再退回定义处路径。
+  dynamicInjectedElements.add(openingElement.start);
+
+  const insertPosition =
+    openingElement.end - (openingElement.selfClosing ? 2 : 1);
+  const addition = ` ${PathName}={${propExpression} || ${JSON.stringify(
+    getNodePathValue(filePath, node, nodeName),
+  )}}${openingElement.attributes.length ? ' ' : ''}`;
+
+  s.prependLeft(insertPosition, addition);
+}
+
+function injectStaticCreateElementPath(
+  node: any,
+  s: MagicString,
+  content: string,
+  filePath: string,
+  dynamicInjectedCreateElementCalls: Set<number>,
+  escapeTags: EscapeTags,
+) {
+  if (dynamicInjectedCreateElementCalls.has(node.start)) {
+    return;
+  }
+
+  const nodeName = getCreateElementNodeName(node);
+  if (!nodeName || isEscapedJsxTag(escapeTags, nodeName)) {
+    return;
+  }
+
+  injectCreateElementPath(
+    node,
+    s,
+    content,
+    JSON.stringify(getNodePathValue(filePath, node, nodeName)),
+  );
+}
+
+function injectDynamicCreateElementPath(
+  node: any,
+  s: MagicString,
+  content: string,
+  filePath: string,
+  dynamicInjectedCreateElementCalls: Set<number>,
+  propExpression: string,
+  escapeTags: EscapeTags,
+) {
+  const nodeName = getCreateElementNodeName(node);
+  if (
+    dynamicInjectedCreateElementCalls.has(node.start) ||
+    !nodeName ||
+    isEscapedJsxTag(escapeTags, nodeName)
+  ) {
+    return;
+  }
+
+  // 组件根节点优先显示调用点路径；没有调用点信息时再退回定义处路径。
+  dynamicInjectedCreateElementCalls.add(node.start);
+  injectCreateElementPath(
+    node,
+    s,
+    content,
+    `${propExpression} || ${JSON.stringify(getNodePathValue(filePath, node, nodeName))}`,
+  );
+}
+
+export function injectCreateElementPath(
+  node: any,
+  s: MagicString,
+  content: string,
+  pathExpression: string,
+) {
+  const propsArgument = node.arguments?.[1];
+  if (hasCreateElementPathProperty(propsArgument)) {
+    return;
+  }
+
+  if (!propsArgument) {
+    const typeArgument = node.arguments?.[0];
+    if (!typeArgument?.end) {
+      return;
+    }
+    s.appendLeft(
+      typeArgument.end,
+      `, { ${JSON.stringify(PathName)}: ${pathExpression} }`,
+    );
+    return;
+  }
+
+  if (propsArgument.type === 'ObjectExpression') {
+    s.prependLeft(
+      propsArgument.start + 1,
+      `${JSON.stringify(PathName)}: ${pathExpression}${
+        propsArgument.properties.length ? ', ' : ''
+      }`,
+    );
+    return;
+  }
+
+  s.overwrite(
+    propsArgument.start,
+    propsArgument.end,
+    `Object.assign({}, ${content.slice(
+      propsArgument.start,
+      propsArgument.end,
+    )}, { ${JSON.stringify(PathName)}: ${pathExpression} })`,
+  );
+}
+
+function hasCreateElementPathProperty(node: any) {
+  if (node?.type !== 'ObjectExpression') {
+    return false;
+  }
+
+  return node.properties.some(
+    (property: any) =>
+      property?.type === 'ObjectProperty' &&
+      getObjectPropertyName(property.key) === PathName,
+  );
+}
+
+function hasPathAttribute(attributes: any[] = []) {
+  return attributes.some(
+    (attr: any) =>
+      attr.type !== 'JSXSpreadAttribute' && attr.name?.name === PathName,
+  );
+}
+
+export function getJsxNodeName(node: any): string {
+  if (!node) {
+    return '';
+  }
+
+  if (node.type === 'JSXIdentifier') {
+    return node.name;
+  }
+
+  if (node.type === 'JSXMemberExpression') {
+    return `${getJsxNodeName(node.object)}.${getJsxNodeName(node.property)}`;
+  }
+
+  if (node.type === 'JSXNamespacedName') {
+    return `${getJsxNodeName(node.namespace)}:${getJsxNodeName(node.name)}`;
+  }
+
+  return '';
+}
+
+function isCreateElementCall(node: any) {
+  return getCallExpressionName(node?.callee) === 'createElement';
+}
+
+function isCreatePortalCall(node: any) {
+  return getCallExpressionName(node?.callee) === 'createPortal';
+}
+
+function getCreateElementNodeName(node: any): string {
+  if (!isCreateElementCall(node)) {
+    return '';
+  }
+
+  return getExpressionName(node.arguments?.[0]);
+}
+
+export function getCallExpressionName(node: any): string {
+  if (!node) {
+    return '';
+  }
+
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+
+  if (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    node.property?.type === 'Identifier'
+  ) {
+    return node.property.name;
+  }
+
+  return '';
+}
+
+export function getExpressionName(node: any): string {
+  if (!node) {
+    return '';
+  }
+
+  if (node.type === 'StringLiteral') {
+    return node.value;
+  }
+
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+
+  if (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    node.property?.type === 'Identifier'
+  ) {
+    return `${getExpressionName(node.object)}.${node.property.name}`;
+  }
+
+  return '';
+}
+
+function isEscapedJsxTag(escapeTags: EscapeTags, nodeName: string) {
+  return (
+    isEscapeTags(escapeTags, nodeName) ||
+    isEscapeTags(escapeTags, nodeName.split('.').pop() || nodeName)
+  );
+}
+
+function getNodePathValue(filePath: string, node: any, nodeName: string) {
+  const { line, column } = node.loc.start;
+  return `${filePath}:${line}:${column + 1}:${nodeName}`;
+}
+
+export const __TEST__ = {
+  hasExportDefaultAncestor,
+  getPropagatedPathExpression,
+  getObjectPatternPathBinding,
+  getObjectPropertyName,
+  getEmptyParamsInsertPosition,
+  collectRootTargets,
+  isEscapedJsxTag,
+};

--- a/packages/core/types/server/transform/transform-jsx.d.ts
+++ b/packages/core/types/server/transform/transform-jsx.d.ts
@@ -1,2 +1,31 @@
+import MagicString from 'magic-string';
 import { EscapeTags } from '../../shared';
+type RootTarget = {
+    type: 'jsx';
+    node: any;
+} | {
+    type: 'createElement';
+    node: any;
+};
 export declare function transformJsx(content: string, filePath: string, escapeTags: EscapeTags): string;
+declare function hasExportDefaultAncestor(path: any): boolean;
+declare function getPropagatedPathExpression(path: any, s: MagicString, content: string): string;
+declare function getObjectPatternPathBinding(param: any): string;
+declare function getObjectPropertyName(node: any): string;
+declare function getEmptyParamsInsertPosition(node: any, content: string): any;
+declare function collectRootTargets(node: any, scope: any, visitedBindings?: Set<string>): RootTarget[];
+export declare function injectCreateElementPath(node: any, s: MagicString, content: string, pathExpression: string): void;
+export declare function getJsxNodeName(node: any): string;
+export declare function getCallExpressionName(node: any): string;
+export declare function getExpressionName(node: any): string;
+declare function isEscapedJsxTag(escapeTags: EscapeTags, nodeName: string): boolean;
+export declare const __TEST__: {
+    hasExportDefaultAncestor: typeof hasExportDefaultAncestor;
+    getPropagatedPathExpression: typeof getPropagatedPathExpression;
+    getObjectPatternPathBinding: typeof getObjectPatternPathBinding;
+    getObjectPropertyName: typeof getObjectPropertyName;
+    getEmptyParamsInsertPosition: typeof getEmptyParamsInsertPosition;
+    collectRootTargets: typeof collectRootTargets;
+    isEscapedJsxTag: typeof isEscapedJsxTag;
+};
+export {};

--- a/test/core/server/transform/transform-jsx.test.ts
+++ b/test/core/server/transform/transform-jsx.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { transformJsx } from '@/core/src/server/transform/transform-jsx';
+import {
+  __TEST__,
+  getCallExpressionName,
+  getExpressionName,
+  getJsxNodeName,
+  injectCreateElementPath,
+  transformJsx,
+} from '@/core/src/server/transform/transform-jsx';
 import { PathName } from '@/core/src/shared/constant';
 
 describe('transformJsx', () => {
@@ -11,8 +18,9 @@ describe('transformJsx', () => {
       const content = 'function App() { return <div>Hello</div>; }';
       const result = transformJsx(content, filePath, defaultEscapeTags);
 
-      // Column is 0-indexed + 1, so column 24 (0-indexed) becomes 25
-      expect(result).toContain(`${PathName}="${filePath}:1:25:div"`);
+      // Component root elements get dynamic path injection with prop propagation
+      expect(result).toContain(`|| "${filePath}:1:25:div"`);
+      expect(result).toContain(`${PathName}={`);
     });
 
     it('should add data-insp-path to nested elements', () => {
@@ -33,24 +41,32 @@ describe('transformJsx', () => {
       const content = 'function App() { return <input type="text" />; }';
       const result = transformJsx(content, filePath, defaultEscapeTags);
 
-      // Column is 0-indexed + 1
-      expect(result).toContain(`${PathName}="${filePath}:1:25:input"`);
+      // Component root elements get dynamic path injection
+      expect(result).toContain(`|| "${filePath}:1:25:input"`);
+    });
+
+    it('should handle self-closing elements in non-component code with static injection', () => {
+      const content = 'const el = <input />;';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`${PathName}="${filePath}:1:12:input"`);
     });
 
     it('should add space after path attribute when element has existing attributes', () => {
       const content = 'function App() { return <div className="test">Hello</div>; }';
       const result = transformJsx(content, filePath, defaultEscapeTags);
 
-      // Column is 0-indexed + 1
-      expect(result).toContain(`${PathName}="${filePath}:1:25:div" `);
+      // Root element gets dynamic path with trailing space for existing attributes
+      expect(result).toContain(`|| "${filePath}:1:25:div"}`);
+      expect(result).toContain(`${PathName}={`);
     });
 
     it('should not add extra space when element has no attributes', () => {
       const content = 'function App() { return <div>Hello</div>; }';
       const result = transformJsx(content, filePath, defaultEscapeTags);
 
-      // Column is 0-indexed + 1
-      expect(result).toContain(`${PathName}="${filePath}:1:25:div">`);
+      // Root element gets dynamic path, closes directly into >
+      expect(result).toContain(`|| "${filePath}:1:25:div"}`);
     });
   });
 
@@ -89,14 +105,19 @@ describe('transformJsx', () => {
       const content = `function App() { return <div ${PathName}="existing/path">Hello</div>; }`;
       const result = transformJsx(content, filePath, defaultEscapeTags);
 
-      expect(result).toBe(content);
+      // Existing path attribute should be preserved (not overwritten with a new path)
+      expect(result).toContain(`${PathName}="existing/path"`);
+      // No dynamic path injection since attribute already exists
+      expect(result).not.toContain(`|| "existing/path"`);
     });
 
     it('should skip self-closing elements that already have data-insp-path', () => {
       const content = `function App() { return <input ${PathName}="existing/path" />; }`;
       const result = transformJsx(content, filePath, defaultEscapeTags);
 
-      expect(result).toBe(content);
+      // Existing path attribute should be preserved
+      expect(result).toContain(`${PathName}="existing/path"`);
+      expect(result).not.toContain(`|| "existing/path"`);
     });
 
     it('should not skip elements with spread attributes', () => {
@@ -296,6 +317,866 @@ function App() {
       expect(result).toContain(`:article"`);
       expect(result).toContain(`:p"`);
       expect(result).toContain(`:span"`);
+    });
+  });
+
+  describe('function expressions and arrow functions', () => {
+    it('should handle function expressions assigned to variables', () => {
+      const content = 'const App = function() { return <div>Hello</div>; };';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle arrow function components', () => {
+      const content = 'const App = () => <div>Hello</div>;';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle arrow function with block body', () => {
+      const content = 'const App = () => { return <div>Hello</div>; };';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('class components', () => {
+    it('should handle class component with extends and render method', () => {
+      const content = `
+class MyApp extends React.Component {
+  render() {
+    return <div>Hello</div>;
+  }
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      // Class components use this.props for path propagation
+      expect(result).toContain('this.props');
+    });
+
+    it('should handle class expression assigned to variable', () => {
+      const content = `
+const MyApp = class extends React.Component {
+  render() {
+    return <div>Hello</div>;
+  }
+};`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should not transform class without superClass', () => {
+      const content = `
+class NotAComponent {
+  render() {
+    return <div>Hello</div>;
+  }
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // Still transforms JSX elements via the general enter handler
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should not transform class without render method', () => {
+      const content = `
+class MyApp extends React.Component {
+  doSomething() {
+    return <div>Hello</div>;
+  }
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // Not a valid component class (no render), but JSX in enter handler still works
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle class with inner function in render', () => {
+      const content = `
+class MyApp extends React.Component {
+  render() {
+    const helper = () => <span>inner</span>;
+    return <div>Hello</div>;
+  }
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      expect(result).toContain(`:span"`);
+    });
+
+    it('should handle class with inner class in render', () => {
+      const content = `
+class MyApp extends React.Component {
+  render() {
+    class Inner {}
+    return <div>Hello</div>;
+  }
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('component owner name detection', () => {
+    it('should detect assignment expression component name', () => {
+      const content = `
+let MyComponent;
+MyComponent = function() { return <div>Hello</div>; };`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should not treat lowercase function as component', () => {
+      const content = 'function helper() { return <div>Hello</div>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // lowercase function is not treated as a component, but JSX still gets static path via enter handler
+      expect(result).toContain(`:div"`);
+      // Should NOT have dynamic path propagation (no __codeInspectorProps)
+      expect(result).not.toContain('__codeInspectorProps');
+    });
+  });
+
+  describe('parameter path expression handling', () => {
+    it('should handle component with named props parameter', () => {
+      const content = 'function App(props) { return <div>Hello</div>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // Should use existing props parameter for path propagation
+      expect(result).toContain('props &&');
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle destructured props parameter', () => {
+      const content = 'function App({ name }) { return <div>{name}</div>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      // Should inject path binding into destructured pattern
+      expect(result).toContain('__codeInspectorPath');
+    });
+
+    it('should handle destructured props with default values', () => {
+      const content = 'function App({ name = "default" }) { return <div>{name}</div>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle destructured props that already have PathName', () => {
+      const content = `function App({ ["${PathName}"]: inspPath }) { return <div>Hello</div>; }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      // Should use existing binding
+      expect(result).toContain('inspPath');
+    });
+
+    it('should handle destructured props with PathName and default value', () => {
+      const content = `function App({ "${PathName}": inspPath = "" }) { return <div>Hello</div>; }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle props with AssignmentPattern', () => {
+      const content = 'function App(props = {}) { return <div>Hello</div>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      expect(result).toContain('props &&');
+    });
+  });
+
+  describe('createElement calls', () => {
+    it('should handle React.createElement calls', () => {
+      const content = `function App() { return React.createElement("div", null, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(PathName);
+    });
+
+    it('should handle createElement with object props', () => {
+      const content = `function App() { return React.createElement("div", { className: "test" }, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(PathName);
+    });
+
+    it('should handle createElement with empty object props', () => {
+      const content = `function helper() { return React.createElement("div", {}, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`{"${PathName}": "${filePath}:1:28:div"}`);
+    });
+
+    it('should handle createElement with variable props', () => {
+      const content = `function App() { const p = {}; return React.createElement("div", p, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(PathName);
+    });
+
+    it('should handle createElement with no props argument', () => {
+      const content = `function App() { return React.createElement("span"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(PathName);
+    });
+
+    it('should skip createElement with existing path property', () => {
+      const content = `function App() { return React.createElement("div", { "${PathName}": "existing" }, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain('"existing"');
+    });
+
+    it('should skip createElement for escaped tags', () => {
+      const content = `function App() { return React.createElement("script", null, "code"); }`;
+      const result = transformJsx(content, filePath, ['script']);
+
+      // script is escaped, so no path injection
+      expect(result).not.toContain(`:script"`);
+    });
+  });
+
+  describe('collectRootTargets - conditional and logical expressions', () => {
+    it('should handle ternary expression as root return', () => {
+      const content = 'const App = () => condition ? <div>A</div> : <span>B</span>;';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      expect(result).toContain(`:span"`);
+    });
+
+    it('should handle logical AND expression', () => {
+      const content = 'const App = () => show && <div>Hello</div>;';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle logical OR expression', () => {
+      const content = 'const App = () => fallback || <div>Hello</div>;';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle sequence expression (comma operator)', () => {
+      const content = 'const App = () => (sideEffect(), <div>Hello</div>);';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle array expression return', () => {
+      const content = 'const App = () => [<div key="1">A</div>, <span key="2">B</span>];';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      expect(result).toContain(`:span"`);
+    });
+
+    it('should handle array with spread elements', () => {
+      const content = `const App = () => { const items = []; return [...items, <div>A</div>]; };`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle nested fragments with expression containers', () => {
+      const content = `const App = () => <><div>A</div>{condition && <span>B</span>}</>;`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      expect(result).toContain(`:span"`);
+    });
+
+    it('should handle nested fragments within fragments', () => {
+      const content = `const App = () => <><><div>A</div></></>;`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('identifier root targets and variable tracking', () => {
+    it('should handle uppercase component returning undefined identifier', () => {
+      const content = `function App() { return undefined; }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain('__codeInspectorProps');
+      expect(result).not.toContain(PathName);
+    });
+
+    it('should track JSX assigned to variable and returned', () => {
+      const content = `function App() {
+  const el = <div>Hello</div>;
+  return el;
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should track variable assigned later and returned', () => {
+      const content = `function App() {
+  let el;
+  el = <div>Hello</div>;
+  return el;
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle undefined identifier', () => {
+      const content = `function helper() { return undefined; }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // lowercase function, no JSX, should be unchanged
+      expect(result).toBe(content);
+    });
+
+    it('should stop tracking cyclic identifier bindings', () => {
+      const content = `function App() {
+  const first = second;
+  const second = first;
+  return first;
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain('__codeInspectorProps');
+      expect(result).not.toContain(PathName);
+    });
+  });
+
+  describe('createPortal support', () => {
+    it('should handle ReactDOM.createPortal', () => {
+      const content = `function App() { return ReactDOM.createPortal(<div>Portal</div>, document.body); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('JSX member expressions and namespaced names', () => {
+    it('should handle member expression tag names', () => {
+      const content = 'function App() { return <Foo.Bar>Hello</Foo.Bar>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(':Foo.Bar"');
+    });
+
+    it('should handle namespaced names', () => {
+      const content = 'function App() { return <xml:svg>Hello</xml:svg>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(':xml:svg"');
+    });
+
+    it('should escape member expression tag with dot notation', () => {
+      const content = 'function App() { return <UI.Button>Click</UI.Button>; }';
+      const result = transformJsx(content, filePath, ['Button']);
+
+      // "Button" is the last segment, should be escaped
+      expect(result).not.toContain(':UI.Button"');
+    });
+  });
+
+  describe('export default anonymous components', () => {
+    it('should handle export default function expression', () => {
+      const content = 'export default function() { return <div>Hello</div>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle export default arrow function', () => {
+      const content = 'export default () => <div>Hello</div>;';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('non-component code', () => {
+    it('should not crash on code without JSX', () => {
+      const content = 'const x = 1 + 2;';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toBe(content);
+    });
+
+    it('should handle empty function body', () => {
+      const content = 'function helper() {}';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // lowercase function is not a component, should be unchanged
+      expect(result).toBe(content);
+    });
+  });
+
+  describe('getCallExpressionName and getExpressionName', () => {
+    it('should ignore malformed createElement call without type end position', () => {
+      const s = {
+        appendLeft: () => {
+          throw new Error('appendLeft should not be called');
+        },
+      } as any;
+
+      expect(() =>
+        injectCreateElementPath(
+          {
+            arguments: [{}],
+          },
+          s,
+          '',
+          '"path"',
+        ),
+      ).not.toThrow();
+    });
+
+    it('should ignore createElement calls without a type argument', () => {
+      const content = `function App() { return React.createElement(); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain('__codeInspectorProps');
+      expect(result).not.toContain(PathName);
+    });
+
+    it('should handle createElement called as plain function', () => {
+      const content = `function App() { return createElement("div", null, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(PathName);
+    });
+
+    it('should handle nested member expression in createElement', () => {
+      const content = `function App() { return React.DOM.createElement("div", null, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // The callee is a nested member expression — getCallExpressionName reads property.name
+      expect(result).toContain(PathName);
+    });
+
+    it('should handle createElement with MemberExpression tag', () => {
+      const content = `function App() { return React.createElement(Components.Div, null, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(PathName);
+    });
+
+    it('should handle createElement with StringLiteral tag', () => {
+      const content = `function App() { return React.createElement("section", null, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:section"`);
+    });
+
+    it('should skip createElement with unsupported literal tag type', () => {
+      const content = `function App() { return React.createElement(123, null, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain('__codeInspectorProps');
+      expect(result).not.toContain(PathName);
+    });
+
+    it('should return empty call expression name for missing callee', () => {
+      expect(getCallExpressionName(undefined)).toBe('');
+    });
+
+    it('should return empty JSX node name for unsupported node types', () => {
+      expect(getJsxNodeName({ type: 'JSXSpreadChild' })).toBe('');
+    });
+
+    it('should return empty expression name for missing and unsupported expressions', () => {
+      expect(getExpressionName(undefined)).toBe('');
+      expect(getExpressionName({ type: 'NumericLiteral', value: 1 })).toBe('');
+    });
+  });
+
+  describe('unwrapRenderableExpression', () => {
+    it('should handle parenthesized expression', () => {
+      const content = 'function App() { return (<div>Hello</div>); }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle TS as expression', () => {
+      const content = 'function App() { return <div>Hello</div> as any; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle TS non-null assertion', () => {
+      const content = `function App() {
+  const el = <div>Hello</div>;
+  return el!;
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('containsRenderableReturn', () => {
+    it('should detect component in export default with arrow body', () => {
+      const content = 'export default () => <div>Hello</div>;';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should not detect non-renderable export default', () => {
+      const content = 'export default () => 42;';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toBe(content);
+    });
+
+    it('should detect component export default with block body return', () => {
+      const content = `export default function() { return <div>Hello</div>; }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('hasExportDefaultAncestor boundary', () => {
+    it('should not treat function inside class as export default', () => {
+      const content = `
+class Wrapper {
+  method() {
+    const fn = function() { return <div>Hello</div>; };
+    return fn;
+  }
+}
+export default Wrapper;`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // fn is inside a class method, not a direct export default
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should not treat nested function as export default component', () => {
+      const content = `
+function outer() {
+  return function() { return <div>Hello</div>; };
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('getEmptyParamsInsertPosition edge cases', () => {
+    it('should handle arrow function without parens', () => {
+      // Arrow functions like `x => <div/>` have params so this doesn't apply
+      // But `() => <div/>` does - testing the position detection
+      const content = 'const App = () => <div>Hello</div>;';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('export default class component', () => {
+    it('should handle export default class with render returning JSX', () => {
+      const content = `
+export default class extends React.Component {
+  render() {
+    return <div>Hello</div>;
+  }
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      expect(result).toContain('this.props');
+    });
+  });
+
+  describe('containsRenderableReturn internals', () => {
+    it('should skip inner functions and classes in containsRenderableReturn', () => {
+      // export default with block body containing inner function and class
+      const content = `
+export default function() {
+  class Inner {}
+  const helper = function() { return <span>inner</span>; };
+  return <div>Hello</div>;
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle containsMethodRenderableReturn with inner function and class', () => {
+      // Class component where render has inner functions/classes
+      const content = `
+export default class extends React.Component {
+  render() {
+    class InnerClass {}
+    const helper = function() { return <span>nested</span>; };
+    return <div>Hello</div>;
+  }
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('createElement in component root', () => {
+    it('should inject dynamic path for component root createElement', () => {
+      const content = `function App() { return React.createElement("div", null, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // Root createElement in component gets dynamic path propagation
+      expect(result).toContain(PathName);
+    });
+
+    it('should handle non-component createElement (static injection)', () => {
+      const content = `function helper() { return React.createElement("div", null, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // Static createElement injection for non-component
+      expect(result).toContain(PathName);
+    });
+
+    it('should handle createElement with variable prop as root return', () => {
+      const content = `function App() { const p = { className: "test" }; return React.createElement("div", p, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // Variable props gets Object.assign wrapper
+      expect(result).toContain('Object.assign');
+    });
+
+    it('should handle createElement with no args beyond type', () => {
+      const content = `function helper() { return React.createElement("br"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(PathName);
+    });
+  });
+
+  describe('edge cases for identifier tracking', () => {
+    it('should handle circular variable references', () => {
+      // Variable referencing itself should not infinite loop
+      const content = `function App() {
+  let el = <div>Initial</div>;
+  el = el;
+  return el;
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+
+    it('should handle multiple assignments to same variable', () => {
+      // getSingleBindingAssignment returns null when there are multiple assignments
+      const content = `function App() {
+  let el;
+  el = <div>A</div>;
+  el = <span>B</span>;
+  return el;
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // Multiple assignments means getSingleBindingAssignment returns null
+      // but the static enter handler still catches the JSX
+      expect(result).toContain(`:div"`);
+      expect(result).toContain(`:span"`);
+    });
+
+    it('should handle variable without init and no assignments', () => {
+      const content = `function App() {
+  let el;
+  return el;
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // el is uninitialized, no assignments - returns empty targets
+      expect(result).toContain('__codeInspectorProps');
+    });
+
+    it('should handle non-VariableDeclarator binding', () => {
+      // Function parameter binding is not a VariableDeclarator - returns empty
+      const content = `function App(el) {
+  return el;
+}`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // el is a function param, not a VariableDeclarator - no root target found
+      // so no dynamic path injection on the return value
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('array with sparse elements', () => {
+    it('should handle array with holes (sparse array)', () => {
+      const content = `const App = () => [<div key="1">A</div>, , <span key="2">B</span>];`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      expect(result).toContain(`:span"`);
+    });
+  });
+
+  describe('fragment with text and non-JSX children', () => {
+    it('should handle fragment with text children', () => {
+      const content = `const App = () => <>Hello<div>World</div>text</>;`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('createPortal as root of component', () => {
+    it('should follow createPortal first argument for root injection', () => {
+      const content = `function App() { return ReactDOM.createPortal(<div>Portal</div>, container); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('computed member expression in callee', () => {
+    it('should handle computed member expression callee', () => {
+      // computed member expression - getCallExpressionName returns ''
+      const content = `function helper() { return React["createElement"]("div", null, "Hello"); }`;
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // computed member expressions are not recognized as createElement calls
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('empty destructured props', () => {
+    it('should handle empty destructured props object', () => {
+      const content = 'function App({}) { return <div>Hello</div>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      expect(result).toContain(`:div"`);
+      expect(result).toContain('__codeInspectorPath');
+    });
+  });
+
+  describe('rest parameter', () => {
+    it('should handle rest parameter as first param', () => {
+      const content = 'function App(...args) { return <div>Hello</div>; }';
+      const result = transformJsx(content, filePath, defaultEscapeTags);
+
+      // RestElement is not Identifier/ObjectPattern/AssignmentPattern - returns ''
+      // This means getPropagatedPathExpression returns '' and no dynamic injection happens
+      expect(result).toContain(`:div"`);
+    });
+  });
+
+  describe('internal helper fallbacks', () => {
+    it('should return false when no export default ancestor exists', () => {
+      expect(
+        __TEST__.hasExportDefaultAncestor({
+          parentPath: {
+            isExportDefaultDeclaration: () => false,
+            isClass: () => false,
+            isFunction: () => false,
+            isObjectMethod: () => false,
+            parentPath: null,
+          },
+        }),
+      ).toBe(false);
+    });
+
+    it('should return empty propagated expression when implicit props insertion is unavailable', () => {
+      expect(
+        __TEST__.getPropagatedPathExpression(
+          {
+            node: {
+              params: [],
+              body: {},
+            },
+          },
+          {
+            prependLeft: () => {
+              throw new Error('prependLeft should not be called');
+            },
+          },
+          'function App() { return <div />; }',
+        ),
+      ).toBe('');
+    });
+
+    it('should return empty string for missing or unsupported object property names', () => {
+      expect(__TEST__.getObjectPropertyName(null)).toBe('');
+      expect(__TEST__.getObjectPropertyName({ type: 'NumericLiteral', value: 1 })).toBe('');
+    });
+
+    it('should return empty string when object pattern properties are missing', () => {
+      expect(__TEST__.getObjectPatternPathBinding({})).toBe('');
+    });
+
+    it('should return null when empty params insertion position cannot be resolved', () => {
+      expect(
+        __TEST__.getEmptyParamsInsertPosition(
+          {
+            body: {},
+          },
+          'function App() { return <div />; }',
+        ),
+      ).toBeNull();
+
+      expect(
+        __TEST__.getEmptyParamsInsertPosition(
+          {
+            start: 0,
+            body: {
+              start: 15,
+            },
+          },
+          'function App => ',
+        ),
+      ).toBeNull();
+    });
+
+    it('should return an empty root target list for null nodes', () => {
+      expect(__TEST__.collectRootTargets(null, null)).toEqual([]);
+    });
+
+    it('should tolerate bindings without identifier metadata or constant violations', () => {
+      expect(
+        __TEST__.collectRootTargets(
+          {
+            type: 'Identifier',
+            name: 'el',
+          },
+          {
+            getBinding: () => ({
+              identifier: {},
+              path: {
+                node: {
+                  type: 'VariableDeclarator',
+                },
+                scope: null,
+              },
+            }),
+          },
+        ),
+      ).toEqual([]);
+    });
+
+    it('should fall back to the original node name when escaped tag suffix is empty', () => {
+      expect(__TEST__.isEscapedJsxTag(['bar'], 'Foo.')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
close #505 

## Summary

  This PR improves JSX transformation for React-style components so root nodes
  can preserve and propagate `data-insp-path` from the component call site
  instead of always falling back to the component definition location.

  ## What changed

  - detect React component functions and class components more accurately
  - inject dynamic `data-insp-path` handling for component root JSX elements
  - support component root `createElement(...)` and `createPortal(...)` returns
  - resolve root render targets through conditionals, logical expressions,
  arrays, fragments, identifiers, and assignments
  - handle props path propagation for:
    - standard props identifiers
    - destructured props
    - destructured props with defaults
    - components without explicit params
  - improve JSX tag name handling for member expressions and namespaced tags
  - avoid duplicate injection when a path attribute or path prop already exists
  - export helper utilities and add declaration updates needed by the expanded
  test coverage

  ## Tests

  - expand `transform-jsx` coverage across component detection, root target
  collection, `createElement` injection, class components, export-default
  anonymous components, and edge-case fallbacks
  - verified with:

  ```bash
  pnpm vitest run test/core/server/transform/transform-jsx.test.ts --coverage