### PR TITLE
fix: windows下执行spawn报错

### DIFF
--- a/packages/core/src/server/ai-provider-claude.ts
+++ b/packages/core/src/server/ai-provider-claude.ts
@@ -198,6 +198,7 @@ export const __TEST_ONLY__ = {
   setupSdkEnvironment,
   buildSdkQueryOptions,
   queryViaSdk,
+  normalizeClaudeCliPathForWindowsSpawn,
   setClaudeQuery: (queryFn: Function | null) => {
     claudeQuery = queryFn;
   },
@@ -538,6 +539,31 @@ export function handleClaudeRequest(
 let cachedCliPath: string | null | undefined = undefined;
 
 /**
+ * Windows 上 `where claude` 常指向 npm 目录里无后缀的 `claude`（实为 Unix shell 脚本）。
+ * `child_process.spawn` 无法将其作为可执行文件启动，会报 ENOENT；同目录下的 `claude.cmd` 才是可 spawn 的入口。
+ */
+function normalizeClaudeCliPathForWindowsSpawn(resolvedPath: string): string {
+  if (process.platform !== 'win32') {
+    return resolvedPath;
+  }
+  const ext = path.extname(resolvedPath).toLowerCase();
+  if (
+    ext === '.cmd' ||
+    ext === '.bat' ||
+    ext === '.exe' ||
+    ext === '.com' ||
+    ext === '.ps1'
+  ) {
+    return resolvedPath;
+  }
+  if (path.basename(resolvedPath) !== 'claude') {
+    return resolvedPath;
+  }
+  const cmdPath = path.join(path.dirname(resolvedPath), 'claude.cmd');
+  return fs.existsSync(cmdPath) ? cmdPath : resolvedPath;
+}
+
+/**
  * 查找本地 Claude Code CLI 路径
  */
 function findClaudeCodeCli(): string | null {
@@ -553,7 +579,8 @@ function findClaudeCodeCli(): string | null {
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
     if (result) {
-      cachedCliPath = result.split('\n')[0];
+      const first = result.split(/\r?\n/)[0].trim();
+      cachedCliPath = normalizeClaudeCliPathForWindowsSpawn(first);
       return cachedCliPath;
     }
   } catch {
@@ -571,7 +598,7 @@ function findClaudeCodeCli(): string | null {
 
   for (const p of possiblePaths) {
     if (fs.existsSync(p)) {
-      cachedCliPath = p;
+      cachedCliPath = normalizeClaudeCliPathForWindowsSpawn(p);
       return cachedCliPath;
     }
   }

--- a/test/core/server/ai/claude-provider-helpers.test.ts
+++ b/test/core/server/ai/claude-provider-helpers.test.ts
@@ -546,6 +546,33 @@ describe('claude provider helpers', () => {
     }
   });
 
+  it('should normalize npm claude shim to claude.cmd on win32', () => {
+    const oldPlatform = process.platform;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ci-claude-shim-'));
+    const shimPath = path.join(dir, 'claude');
+    const cmdPath = path.join(dir, 'claude.cmd');
+    fs.writeFileSync(shimPath, '#!/bin/sh\n');
+    fs.writeFileSync(cmdPath, '@echo off\n');
+
+    try {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: 'win32',
+      });
+      expect(__TEST_ONLY__.normalizeClaudeCliPathForWindowsSpawn(shimPath)).toBe(
+        cmdPath,
+      );
+      expect(__TEST_ONLY__.normalizeClaudeCliPathForWindowsSpawn(cmdPath)).toBe(
+        cmdPath,
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: oldPlatform,
+      });
+    }
+  });
+
   it('should cover sdk environment/bootstrap branches and dynamic getClaudeQuery load', async () => {
     const originalEnv = process.env as any;
     (process as any).env = undefined;


### PR DESCRIPTION
---
name: windows下执行spawn报错
about: windows下执行spawn报错
---

> 提示：越详细的信息越有助于排查和解决问题，如果方便请加入本项目 README.md 最下面的 QQ 群或者微信群提供更详细的信息

## 插件版本

2.0.0-beta.6

## Bug 类型

- [ ] 安装插件后启动项目编译失败
- [ ] 按住组合键无筛选框
- [ ] 点击筛选框无法打开 IDE
- [ √] 其他问题

## Bug 描述
使用AI Assistant功能，使用的是claude code 的cli模式，在对话框发送信息以后，控制台报错如下，原因是windows下执行where claude 找到的 claude文件不是spawn可以执行的文件，应该执行claude.cmd
<img width="866" height="157" alt="image" src="https://github.com/user-attachments/assets/7575a9b3-4ed5-437e-9d4b-3bf72fd25ed4" />

## 系统

- [√ ] windows(未使用 wsl 虚拟机)
- [ ] windows(使用了 wsl 虚拟机)
- [ ] mac
- [ ] linux

## 你使用的打包器及版本

- [ ] webpack
- [√ ] vite
- [ ] rspack
- [ ] umijs
- [ ] 其他

## 你使用的 web 框架

- [ ] react
- [√ ] vue
- [ ] nuxt
- [ ] next.js
- [ ] svelte
- [ ] astro
- [ ] solid
- [ ] preact
- [ ] qwik
- [ ] 其他

## 自检信息

- [ √] 你的浏览器、IDE、代码是否在一台机器上(非远程开发机或者云开发机情况)
- [ √] 浏览器控制台是否有打印组合按键提示信息<br />
      <img src="https://github.com/zh-lx/code-inspector/assets/73059627/77bcef30-88a5-4f58-b306-a92e01ecef8f" width="500" />

- [ √] 页面 DOM 是否有注入 `data-insp-path` 属性<br />
      <img src="https://github.com/zh-lx/code-inspector/assets/73059627/0523f9fb-e755-4561-9284-8970e4081bcc" width="600" />
