### PR TITLE
fix: windows下执行spawn报错

### DIFF
--- a/packages/core/src/server/ai-provider-claude.ts
+++ b/packages/core/src/server/ai-provider-claude.ts
@@ -241,6 +241,7 @@ export async function getModelInfo(
         {
           stdio: ['pipe', 'pipe', 'pipe'],
           env: getEnvVars(),
+          ...(cliPathNeedsShellSpawnOnWindows(cliPath) ? { shell: true } : {}),
         },
       );
       child.stdin?.end();
@@ -538,6 +539,42 @@ export function handleClaudeRequest(
 let cachedCliPath: string | null | undefined = undefined;
 
 /**
+ * Windows 上 `where claude` 常指向 npm 目录里无后缀的 `claude`（实为 Unix shell 脚本）。
+ * `child_process.spawn` 无法将其作为可执行文件启动，会报 ENOENT；同目录下的 `claude.cmd` 才是可 spawn 的入口。
+ */
+function normalizeClaudeCliPathForWindowsSpawn(resolvedPath: string): string {
+  if (process.platform !== 'win32') {
+    return resolvedPath;
+  }
+  const ext = path.extname(resolvedPath).toLowerCase();
+  if (
+    ext === '.cmd' ||
+    ext === '.bat' ||
+    ext === '.exe' ||
+    ext === '.com' ||
+    ext === '.ps1'
+  ) {
+    return resolvedPath;
+  }
+  if (path.basename(resolvedPath) !== 'claude') {
+    return resolvedPath;
+  }
+  const cmdPath = path.join(path.dirname(resolvedPath), 'claude.cmd');
+  return fs.existsSync(cmdPath) ? cmdPath : resolvedPath;
+}
+
+/**
+ * Windows 上不能直接 spawn `.cmd`/`.bat`/`.ps1`（会 EINVAL），需 `shell: true` 经 cmd 解释。
+ */
+function cliPathNeedsShellSpawnOnWindows(cliPath: string): boolean {
+  if (process.platform !== 'win32') {
+    return false;
+  }
+  const ext = path.extname(cliPath).toLowerCase();
+  return ext === '.cmd' || ext === '.bat' || ext === '.ps1';
+}
+
+/**
  * 查找本地 Claude Code CLI 路径
  */
 function findClaudeCodeCli(): string | null {
@@ -553,7 +590,8 @@ function findClaudeCodeCli(): string | null {
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
     if (result) {
-      cachedCliPath = result.split('\n')[0];
+      const first = result.split(/\r?\n/)[0].trim();
+      cachedCliPath = normalizeClaudeCliPathForWindowsSpawn(first);
       return cachedCliPath;
     }
   } catch {
@@ -571,7 +609,7 @@ function findClaudeCodeCli(): string | null {
 
   for (const p of possiblePaths) {
     if (fs.existsSync(p)) {
-      cachedCliPath = p;
+      cachedCliPath = normalizeClaudeCliPathForWindowsSpawn(p);
       return cachedCliPath;
     }
   }
@@ -666,6 +704,7 @@ function queryViaCli(
     cwd,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
+    ...(cliPathNeedsShellSpawnOnWindows(cliPath) ? { shell: true } : {}),
   });
 
   if (inputMessage) {

--- a/packages/core/src/server/ai-provider-claude.ts
+++ b/packages/core/src/server/ai-provider-claude.ts
@@ -51,6 +51,35 @@ interface ClaudeCliInputMessage {
 const INLINE_IMAGE_DATA_URL_REGEX =
   /data:(image\/[a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=]+)/g;
 
+const CLAUDE_MODEL_LOG_MAX_CHARS = 1800;
+
+function truncateForLog(text: string, max = CLAUDE_MODEL_LOG_MAX_CHARS): string {
+  if (!text) return '';
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}...[truncated ${text.length - max} chars]`;
+}
+
+function stringifyForLog(value: unknown): string {
+  if (typeof value === 'string') {
+    return truncateForLog(value);
+  }
+  try {
+    return truncateForLog(JSON.stringify(value));
+  } catch {
+    return truncateForLog(String(value));
+  }
+}
+
+function logClaudeModelIO(stage: string, payload: unknown): void {
+  const prefix = chalk.gray('[claude-model-io]');
+  const output = stringifyForLog(payload);
+  if (output) {
+    console.log(`${prefix} ${stage}: ${output}`);
+  } else {
+    console.log(`${prefix} ${stage}`);
+  }
+}
+
 function stripInlineImageDataUrls(text: string): string {
   return text.replace(
     INLINE_IMAGE_DATA_URL_REGEX,
@@ -235,13 +264,20 @@ export async function getModelInfo(
 
   try {
     const model = await new Promise<string>((resolve) => {
+      const probeArgs = ['-p', 'hi', '--output-format', 'stream-json', '--verbose'];
+      const probeUseShell = cliPathNeedsShellSpawnOnWindows(cliPath);
+      logClaudeModelIO('probe.spawn', {
+        cliPath,
+        args: probeArgs,
+        shell: probeUseShell,
+      });
       const child = spawn(
         cliPath,
-        ['-p', 'hi', '--output-format', 'stream-json', '--verbose'],
+        probeArgs,
         {
           stdio: ['pipe', 'pipe', 'pipe'],
           env: getEnvVars(),
-          ...(cliPathNeedsShellSpawnOnWindows(cliPath) ? { shell: true } : {}),
+          ...(probeUseShell ? { shell: true } : {}),
         },
       );
       child.stdin?.end();
@@ -259,6 +295,7 @@ export async function getModelInfo(
 
         for (const line of lines) {
           if (!line.trim()) continue;
+          logClaudeModelIO('probe.stdout', line);
           try {
             const event = JSON.parse(line);
             if (event.type === 'system' && event.model) {
@@ -634,7 +671,16 @@ function queryViaCli(
   onSessionId?: (id: string) => void,
 ): ChildProcess {
   const opts = getClaudeCliOptions(aiOptions);
-  const args = inputMessage
+  // On Windows with shell spawning, long multiline prompt passed as CLI args can
+  // be mangled by cmd parsing. Force stream-json stdin input to avoid arg parsing issues.
+  const forceStreamInputOnWindows = process.platform === 'win32';
+  const effectiveInputMessage =
+    inputMessage ||
+    (forceStreamInputOnWindows
+      ? buildClaudeCliInputMessage(prompt, [], sessionId)
+      : undefined);
+
+  const args = effectiveInputMessage
     ? [
         '-p',
         '--output-format',
@@ -699,16 +745,28 @@ function queryViaCli(
   }
 
   const env = { ...getEnvVars(), ...opts?.env };
+  const useShell = cliPathNeedsShellSpawnOnWindows(cliPath);
+  logClaudeModelIO('cli.spawn', {
+    cliPath,
+    args,
+    cwd,
+    shell: useShell,
+    hasInputMessage: Boolean(effectiveInputMessage),
+    promptPreview: effectiveInputMessage ? '[sent via stream-json stdin]' : prompt,
+  });
 
   const child = spawn(cliPath, args, {
     cwd,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
-    ...(cliPathNeedsShellSpawnOnWindows(cliPath) ? { shell: true } : {}),
+    ...(useShell ? { shell: true } : {}),
   });
 
-  if (inputMessage) {
-    child.stdin?.write(`${JSON.stringify(inputMessage)}\n`);
+  if (effectiveInputMessage) {
+    logClaudeModelIO('cli.stdin', effectiveInputMessage);
+    child.stdin?.write(`${JSON.stringify(effectiveInputMessage)}\n`);
+  } else {
+    logClaudeModelIO('cli.prompt', prompt);
   }
   child.stdin?.end();
 
@@ -728,6 +786,7 @@ function queryViaCli(
 
     for (const line of lines) {
       if (!line.trim()) continue;
+      logClaudeModelIO('cli.stdout', line);
 
       try {
         const event = JSON.parse(line);
@@ -1036,10 +1095,17 @@ async function queryViaSdk(
   }
 
   const queryOptions = buildSdkQueryOptions(aiOptions, cwd, sessionId);
+  logClaudeModelIO('sdk.query.options', queryOptions);
+  if (typeof prompt === 'string') {
+    logClaudeModelIO('sdk.query.prompt', prompt);
+  } else {
+    logClaudeModelIO('sdk.query.prompt', '[async iterable multimodal input]');
+  }
   if (typeof queryOptions.stderr !== 'function') {
     queryOptions.stderr = (data: string) => {
       const text = String(data || '').trim();
       if (text) {
+        logClaudeModelIO('sdk.stderr', text);
         sendSSE({ type: 'info', message: text });
       }
     };
@@ -1081,6 +1147,7 @@ async function queryViaSdk(
 
   try {
     for await (const sdkMessage of conversation) {
+      logClaudeModelIO('sdk.event', sdkMessage);
       if (isAborted()) {
         conversation.interrupt();
         break;

--- a/packages/core/types/server/ai-provider-claude.d.ts
+++ b/packages/core/types/server/ai-provider-claude.d.ts
@@ -88,7 +88,7 @@ declare function findClaudeCodeCli(): string | null;
  */
 declare function queryViaCli(cliPath: string, prompt: string, inputMessage: ClaudeCliInputMessage | undefined, cwd: string, aiOptions: ClaudeCodeOptions | undefined, onData: (data: string) => void, onError: (error: string) => void, onEnd: () => void, sessionId?: string, onSessionId?: (id: string) => void): ChildProcess;
 declare function getClaudeQuery(): Promise<Function | null>;
-declare function setupSdkEnvironment(aiOptions?: ClaudeCodeOptions): void;
+declare function setupSdkEnvironment(aiOptions?: ClaudeCodeOptions): () => void;
 declare function buildSdkQueryOptions(aiOptions: ClaudeCodeOptions | undefined, cwd: string, sessionId?: string): Record<string, any>;
 declare function queryViaSdk(prompt: string | AsyncIterable<any>, cwd: string, aiOptions: ClaudeCodeOptions | undefined, sessionId: string | undefined, sendSSE: (data: object | string) => void, isAborted: () => boolean): Promise<{
     timedOut: boolean;


### PR DESCRIPTION
---
name: windows下执行spawn报错
about: windows下执行spawn报错
---

> 提示：越详细的信息越有助于排查和解决问题，如果方便请加入本项目 README.md 最下面的 QQ 群或者微信群提供更详细的信息

## 插件版本

2.0.0-beta.6

## Bug 类型

- [ ] 安装插件后启动项目编译失败
- [ ] 按住组合键无筛选框
- [ ] 点击筛选框无法打开 IDE
- [ √] 其他问题

## Bug 描述

使用AI Assistant功能，使用的是claude code 的cli模式，在对话框发送信息以后，控制台报错如下，原因是windows下执行where claude 找到的 claude文件不是spawn可以执行的文件，应该执行claude.cmd

<img width="433" height="79" alt="企业微信截图_17757406488185" src="https://github.com/user-attachments/assets/27da66ef-7309-4383-aac3-b0e8441b116e" />

## 系统

- [√ ] windows(未使用 wsl 虚拟机)
- [ ] windows(使用了 wsl 虚拟机)
- [ ] mac
- [ ] linux

## 你使用的打包器及版本

- [ ] webpack
- [√ ] vite
- [ ] rspack
- [ ] umijs
- [ ] 其他

## 你使用的 web 框架

- [ ] react
- [√ ] vue
- [ ] nuxt
- [ ] next.js
- [ ] svelte
- [ ] astro
- [ ] solid
- [ ] preact
- [ ] qwik
- [ ] 其他

## 自检信息

- [√ ] 你的浏览器、IDE、代码是否在一台机器上(非远程开发机或者云开发机情况)
- [√ ] 浏览器控制台是否有打印组合按键提示信息<br />
      <img src="https://github.com/zh-lx/code-inspector/assets/73059627/77bcef30-88a5-4f58-b306-a92e01ecef8f" width="500" />

- [√ ] 页面 DOM 是否有注入 `data-insp-path` 属性<br />
      <img src="https://github.com/zh-lx/code-inspector/assets/73059627/0523f9fb-e755-4561-9284-8970e4081bcc" width="600" />
