### PR TITLE
fix: avoid Babel parsing raw HTML under Vite 8 bundledDev

### DIFF
--- a/packages/core/src/server/use-client.ts
+++ b/packages/core/src/server/use-client.ts
@@ -333,7 +333,10 @@ export async function getCodeWithWebComponent({
 
   // 注入消除 warning 代码
   const isTargetFile = await isTargetFileToInject(file, record);
-  if (isTargetFile || inject) {
+  // Babel can only parse JS-type source. Skip non-JS (e.g. raw `.html`) to avoid
+  // "Unexpected token" errors from `addImportToEntry` / `addNextEmptyElementToEntry`.
+  const canParseAsJs = !file || isJsTypeFile(file);
+  if ((isTargetFile || inject) && canParseAsJs) {
     const injectCode = getInjectedCode(
       options,
       getProjectRecord(record)?.port || 0,

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -99,6 +99,17 @@ export function ViteCodeInspectorPlugin(options: Options) {
         return code;
       }
 
+      const [_completePath, query] = id.split('?', 2); // 当前文件的绝对路径
+      let filePath = normalizePath(_completePath);
+
+      // Skip raw HTML entries. In Vite 8 `experimental.bundledDev` mode, rolldown
+      // invokes filterless `transform` hooks on every module including `index.html`
+      // before `vite:build-html` converts it to a JS proxy. Passing raw HTML into
+      // `getCodeWithWebComponent` may trigger Babel `parse()` on HTML and throw.
+      if (filePath.endsWith('.html') && !query) {
+        return code;
+      }
+
       code = await getCodeWithWebComponent({
         options,
         file: id,
@@ -107,9 +118,6 @@ export function ViteCodeInspectorPlugin(options: Options) {
       });
 
       const { escapeTags = [], mappings } = options;
-
-      const [_completePath, query] = id.split('?', 2); // 当前文件的绝对路径
-      let filePath = normalizePath(_completePath);
       filePath = getMappingFilePath(filePath, mappings);
       const params = new URLSearchParams(query);
       // 仅对符合正则的生效


### PR DESCRIPTION
## Summary

- When `experimental.bundledDev: true` is enabled in Vite 8, rolldown invokes filterless `transform` hooks on every module, including the raw `index.html` entry — before `vite:build-html` converts it into a JS proxy.
- The plugin's `transform` hook has no id filter, so raw HTML reaches `getCodeWithWebComponent`, where Babel `parse()` is invoked on the `.html` source and throws `SyntaxError: Unexpected token`.

## Fix

- `packages/vite/src/index.ts`: early-return for raw `.html` ids (no query) before calling `getCodeWithWebComponent`.
- `packages/core/src/server/use-client.ts`: guard the inject path with `isJsTypeFile(file)` so `addImportToEntry` / `addNextEmptyElementToEntry` never feed non-JS sources into Babel.

## Test plan

- [x] Reproduced in a Vite 8 + React demo with `experimental.bundledDev: true` + `codeInspectorPlugin`. Without the fix, dev server throws `Build error ... Unexpected token` while transforming `index.html`. With the fix, the server boots and the bundled output contains correct `data-inspector-path` attributes pointing to the source `.tsx` files (e.g. `src/App.tsx:7:5:div`).
- [x] Verified no regression in classic Vite dev mode (`bundledDev: false`).