### PR TITLE
fix: resolve next from transformed file dir

### DIFF
--- a/packages/core/src/server/use-client.ts
+++ b/packages/core/src/server/use-client.ts
@@ -389,10 +389,7 @@ function writeWebComponentFile(
   return webComponentFilePath;
 }
 
-function normalizeResolveDir(basedir?: string) {
-  if (!basedir) {
-    return process.cwd();
-  }
+function normalizeResolveDir(basedir: string) {
   try {
     if (fs.existsSync(basedir) && fs.statSync(basedir).isFile()) {
       return path.dirname(basedir);
@@ -403,7 +400,7 @@ function normalizeResolveDir(basedir?: string) {
   return basedir;
 }
 
-function resolveNextPackageJson(basedir?: string) {
+function resolveNextPackageJson(basedir: string) {
   const resolveDir = normalizeResolveDir(basedir);
   try {
     const require = createRequire(path.join(resolveDir, 'noop.js'));
@@ -439,7 +436,7 @@ function getNodeModulesPaths(basedir: string) {
   return paths;
 }
 
-function getResolvedNextVersion(basedir?: string) {
+function getResolvedNextVersion(basedir: string) {
   const packageJsonPath = resolveNextPackageJson(basedir);
   if (!packageJsonPath) {
     return '';
@@ -480,10 +477,7 @@ export function isNextGET16(basedir?: string) {
     return isNextVersionGET16(resolvedVersion);
   }
   const dependencies = getDependenciesMap();
-  if (dependencies.next) {
-    return isNextVersionGET16(dependencies.next);
-  }
-  return false;
+  return isNextVersionGET16(dependencies.next || '');
 }
 
 function isNextjsInstrumentationFile(file: string, isNextjs: boolean) {

--- a/packages/core/src/server/use-client.ts
+++ b/packages/core/src/server/use-client.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import chalk from 'chalk';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import MagicString from 'magic-string';
 // @ts-ignore
 import { parse, traverse } from '@babel/core';
@@ -239,7 +240,7 @@ function recordEntry(record: RecordInfo, file: string, isNextjs: boolean) {
   if (
     !getProjectRecord(record)?.entry &&
     isJsTypeFile(file) &&
-    !isNextjsInstrumentationFile(file)
+    !isNextjsInstrumentationFile(file, isNextjs)
   ) {
     // exclude svelte kit server entry file
     if (file.includes('/.svelte-kit/')) {
@@ -321,7 +322,7 @@ export async function getCodeWithWebComponent({
     await startServer(options, record);
   }
 
-  const isNextjs = isNextjsProject();
+  const isNextjs = isNextjsProject(path.dirname(file));
 
   recordInjectTo(record, options);
   recordEntry(record, file, isNextjs);
@@ -388,28 +389,103 @@ function writeWebComponentFile(
   return webComponentFilePath;
 }
 
-export function isNextjsProject() {
+function normalizeResolveDir(basedir?: string) {
+  if (!basedir) {
+    return process.cwd();
+  }
+  try {
+    if (fs.existsSync(basedir) && fs.statSync(basedir).isFile()) {
+      return path.dirname(basedir);
+    }
+  } catch (error) {
+    // Fall back to the provided path and let module resolution fail normally.
+  }
+  return basedir;
+}
+
+function resolveNextPackageJson(basedir?: string) {
+  const resolveDir = normalizeResolveDir(basedir);
+  try {
+    const require = createRequire(path.join(resolveDir, 'noop.js'));
+    const request = 'next/package.json';
+    const resolvedPath = require.resolve(request);
+    const resolvePaths = require.resolve.paths(request) || [];
+    const allowedResolvePaths = getNodeModulesPaths(resolveDir);
+    const matchedResolvePath = resolvePaths.find((resolvePath) => {
+      const normalizedResolvePath = path.resolve(resolvePath);
+      return (
+        allowedResolvePaths.has(normalizedResolvePath) &&
+        fs.existsSync(path.join(normalizedResolvePath, request))
+      );
+    });
+    const hasNextPackageInResolvePaths = Boolean(matchedResolvePath);
+    return hasNextPackageInResolvePaths ? resolvedPath : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function getNodeModulesPaths(basedir: string) {
+  const paths = new Set<string>();
+  let currentDir = path.resolve(basedir);
+  while (true) {
+    paths.add(path.join(currentDir, 'node_modules'));
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      break;
+    }
+    currentDir = parentDir;
+  }
+  return paths;
+}
+
+function getResolvedNextVersion(basedir?: string) {
+  const packageJsonPath = resolveNextPackageJson(basedir);
+  if (!packageJsonPath) {
+    return '';
+  }
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(packageJsonPath, 'utf-8') || '{}',
+    );
+    return packageJson.version || '';
+  } catch (error) {
+    return '';
+  }
+}
+
+function isNextVersionGET16(version: string) {
+  if (!version) {
+    return false;
+  }
+  const majorVersion = version.split('.')[0];
+  if (majorVersion === 'latest') {
+    return true;
+  }
+  const majorVersionNumber = parseInt(majorVersion.replace(/\D/g, ''));
+  return majorVersionNumber >= 16;
+}
+
+export function isNextjsProject(basedir?: string) {
+  if (basedir && resolveNextPackageJson(basedir)) {
+    return true;
+  }
   const dependencies = getDependencies();
   return dependencies.includes('next');
 }
 
-export function isNextGET16() {
+export function isNextGET16(basedir?: string) {
+  const resolvedVersion = basedir ? getResolvedNextVersion(basedir) : '';
+  if (resolvedVersion) {
+    return isNextVersionGET16(resolvedVersion);
+  }
   const dependencies = getDependenciesMap();
   if (dependencies.next) {
-    const version = dependencies.next;
-    const majorVersion = version.split('.')[0];
-    if (majorVersion === 'latest') {
-      return true;
-    }
-    const majorVersionNumber = parseInt(majorVersion.replace(/\D/g, ''));
-    return majorVersionNumber >= 16;
+    return isNextVersionGET16(dependencies.next);
   }
   return false;
 }
 
-function isNextjsInstrumentationFile(file: string) {
-  return (
-    isNextjsProject() &&
-    getFilePathWithoutExt(file).endsWith('/instrumentation')
-  );
+function isNextjsInstrumentationFile(file: string, isNextjs: boolean) {
+  return isNextjs && getFilePathWithoutExt(file).endsWith('/instrumentation');
 }

--- a/packages/core/types/server/use-client.d.ts
+++ b/packages/core/types/server/use-client.d.ts
@@ -12,5 +12,5 @@ export declare function getCodeWithWebComponent({ options, record, file, code, i
     inject?: boolean;
     server?: boolean;
 }): Promise<string>;
-export declare function isNextjsProject(): boolean;
-export declare function isNextGET16(): boolean;
+export declare function isNextjsProject(basedir?: string): boolean;
+export declare function isNextGET16(basedir?: string): boolean;

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         'net',
         'chalk',
         'url',
+        'module',
         'launch-ide',
         'portfinder',
         'child_process',

--- a/packages/turbopack/src/index.ts
+++ b/packages/turbopack/src/index.ts
@@ -74,7 +74,9 @@ export function TurbopackCodeInspectorPlugin(
   ];
 
   const matchFiles = `**/{${validFiles.join(',')}}`;
-  const files = isNextGET16() ? '**/*.{jsx,tsx,js,ts,mjs,mts}' : matchFiles;
+  const files = isNextGET16(process.cwd())
+    ? '**/*.{jsx,tsx,js,ts,mjs,mts}'
+    : matchFiles;
 
   return {
     [files]: {

--- a/test/core/server/use-client/is-nextjs-project.test.ts
+++ b/test/core/server/use-client/is-nextjs-project.test.ts
@@ -1,5 +1,7 @@
 import { expect, describe, it, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
 // Mock fs.readFileSync to handle missing client files and package.json
 vi.mock('fs', async () => {
@@ -40,12 +42,18 @@ import { isNextjsProject, isNextGET16 } from '@/core/src/server/use-client';
 import * as sharedUtils from '@/core/src/shared/utils';
 
 describe('isNextjsProject', () => {
+  let testDir: string;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-next-resolve-'));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    if (testDir && fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
   });
 
   it('should return true when next is in dependencies', () => {
@@ -62,15 +70,33 @@ describe('isNextjsProject', () => {
     vi.spyOn(sharedUtils, 'getDependencies').mockReturnValue([]);
     expect(isNextjsProject()).toBe(false);
   });
+
+  it('should detect next by resolving next/package.json from basedir', () => {
+    const nextPackageDir = path.join(testDir, 'node_modules/next');
+    fs.mkdirSync(nextPackageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nextPackageDir, 'package.json'),
+      JSON.stringify({ name: 'next', version: '16.2.3' }),
+    );
+    vi.spyOn(sharedUtils, 'getDependencies').mockReturnValue([]);
+
+    expect(isNextjsProject(path.join(testDir, 'app'))).toBe(true);
+  });
 });
 
 describe('isNextGET16', () => {
+  let testDir: string;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-next-version-'));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    if (testDir && fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
   });
 
   it('should return true when next version is 16 or higher', () => {
@@ -116,5 +142,33 @@ describe('isNextGET16', () => {
   it('should return false when dependencies map is empty', () => {
     vi.spyOn(sharedUtils, 'getDependenciesMap').mockReturnValue({});
     expect(isNextGET16()).toBe(false);
+  });
+
+  it('should read next version from resolved next/package.json before dependency declarations', () => {
+    const nextPackageDir = path.join(testDir, 'node_modules/next');
+    fs.mkdirSync(nextPackageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nextPackageDir, 'package.json'),
+      JSON.stringify({ name: 'next', version: '16.2.3' }),
+    );
+    vi.spyOn(sharedUtils, 'getDependenciesMap').mockReturnValue({
+      next: '15.0.0',
+    });
+
+    expect(isNextGET16(path.join(testDir, 'app/page.tsx'))).toBe(true);
+  });
+
+  it('should return false when resolved next version is below 16', () => {
+    const nextPackageDir = path.join(testDir, 'node_modules/next');
+    fs.mkdirSync(nextPackageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nextPackageDir, 'package.json'),
+      JSON.stringify({ name: 'next', version: '15.5.0' }),
+    );
+    vi.spyOn(sharedUtils, 'getDependenciesMap').mockReturnValue({
+      next: '16.0.0',
+    });
+
+    expect(isNextGET16(path.join(testDir, 'app/page.tsx'))).toBe(false);
   });
 });

--- a/test/core/server/use-client/is-nextjs-project.test.ts
+++ b/test/core/server/use-client/is-nextjs-project.test.ts
@@ -82,6 +82,38 @@ describe('isNextjsProject', () => {
 
     expect(isNextjsProject(path.join(testDir, 'app'))).toBe(true);
   });
+
+  it('should normalize file basedir before resolving next/package.json', () => {
+    const nextPackageDir = path.join(testDir, 'node_modules/next');
+    const testFile = path.join(testDir, 'app/page.tsx');
+    fs.mkdirSync(nextPackageDir, { recursive: true });
+    fs.mkdirSync(path.dirname(testFile), { recursive: true });
+    fs.writeFileSync(
+      path.join(nextPackageDir, 'package.json'),
+      JSON.stringify({ name: 'next', version: '16.2.3' }),
+    );
+    fs.writeFileSync(testFile, 'export default function Page() {}');
+    vi.spyOn(sharedUtils, 'getDependencies').mockReturnValue([]);
+
+    expect(isNextjsProject(testFile)).toBe(true);
+  });
+
+  it('should fall back to dependencies when basedir stat fails', () => {
+    const testFile = path.join(testDir, 'app/page.tsx');
+    fs.mkdirSync(path.dirname(testFile), { recursive: true });
+    fs.writeFileSync(testFile, 'export default function Page() {}');
+    const originalStatSync = fs.statSync;
+    const statSyncSpy = vi.spyOn(fs, 'statSync').mockImplementation((filePath, options) => {
+      if (filePath === testFile) {
+        throw new Error('stat failed');
+      }
+      return originalStatSync(filePath, options as fs.StatSyncOptions);
+    });
+    vi.spyOn(sharedUtils, 'getDependencies').mockReturnValue(['next']);
+
+    expect(isNextjsProject(testFile)).toBe(true);
+    expect(statSyncSpy).toHaveBeenCalledWith(testFile);
+  });
 });
 
 describe('isNextGET16', () => {
@@ -144,6 +176,16 @@ describe('isNextGET16', () => {
     expect(isNextGET16()).toBe(false);
   });
 
+  it('should return false when basedir cannot resolve next and dependencies map is empty', () => {
+    vi.spyOn(sharedUtils, 'getDependenciesMap').mockReturnValue({});
+    expect(isNextGET16(path.join(testDir, 'app/page.tsx'))).toBe(false);
+  });
+
+  it('should return false when basedir cannot be used for module resolution', () => {
+    vi.spyOn(sharedUtils, 'getDependenciesMap').mockReturnValue({});
+    expect(isNextGET16('relative/page.tsx')).toBe(false);
+  });
+
   it('should read next version from resolved next/package.json before dependency declarations', () => {
     const nextPackageDir = path.join(testDir, 'node_modules/next');
     fs.mkdirSync(nextPackageDir, { recursive: true });
@@ -170,5 +212,25 @@ describe('isNextGET16', () => {
     });
 
     expect(isNextGET16(path.join(testDir, 'app/page.tsx'))).toBe(false);
+  });
+
+  it('should fall back to dependency declarations when resolved next package json cannot be read', () => {
+    const nextPackageDir = path.join(testDir, 'node_modules/next');
+    const nextPackageJsonPath = path.join(nextPackageDir, 'package.json');
+    fs.mkdirSync(nextPackageDir, { recursive: true });
+    fs.writeFileSync(
+      nextPackageJsonPath,
+      JSON.stringify({ name: 'next', version: '16.2.3' }),
+    );
+    fs.chmodSync(nextPackageJsonPath, 0o000);
+    vi.spyOn(sharedUtils, 'getDependenciesMap').mockReturnValue({
+      next: '16.0.0',
+    });
+
+    try {
+      expect(isNextGET16(path.join(testDir, 'app/page.tsx'))).toBe(true);
+    } finally {
+      fs.chmodSync(nextPackageJsonPath, 0o644);
+    }
   });
 });

--- a/test/core/server/use-client/nextjs-integration.test.ts
+++ b/test/core/server/use-client/nextjs-integration.test.ts
@@ -68,8 +68,7 @@ describe('Next.js Integration Tests', () => {
     mockStartServer.mockResolvedValue(undefined);
 
     // Create a temporary test directory
-    testDir = path.join(os.tmpdir(), `test-nextjs-${Date.now()}`);
-    fs.mkdirSync(testDir, { recursive: true });
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-nextjs-'));
   });
 
   afterEach(() => {
@@ -152,6 +151,48 @@ export default function Page() {
 
       // Should still add import even without use client directive
       expect(result).toContain('import');
+    });
+
+    it('should detect Next.js from the transformed file directory when cwd is not a Next.js project', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/test/project/not-next');
+      vi.spyOn(sharedUtils, 'getDependencies').mockReturnValue([]);
+
+      const nextPackageDir = path.join(testDir, 'node_modules/next');
+      fs.mkdirSync(nextPackageDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(nextPackageDir, 'package.json'),
+        JSON.stringify({ name: 'next', version: '16.2.3' }),
+      );
+
+      const testFile = path.join(testDir, 'app/page.tsx');
+      const originalCode = `export default function Page() {
+  return <div>Hello</div>;
+}`;
+      fs.mkdirSync(path.dirname(testFile), { recursive: true });
+      fs.writeFileSync(testFile, originalCode);
+
+      const record: RecordInfo = {
+        port: 0,
+        entry: '',
+        output: testDir,
+      };
+      const options: CodeOptions = {
+        bundler: 'turbopack',
+      };
+
+      setProjectRecord(record, 'entry', path.join(testDir, 'app/page'));
+      setProjectRecord(record, 'port', 5678);
+
+      const result = await getCodeWithWebComponent({
+        options,
+        record,
+        file: testFile,
+        code: originalCode,
+      });
+
+      expect(result).toContain('import CodeInspectorEmptyElement');
+      expect(result).toContain('<CodeInspectorEmptyElement />');
+      expect(result).not.toMatch(/^\/\* eslint-disable \*\/ 'use client';/);
     });
 
     it('should handle nested JSX elements correctly', async () => {

--- a/test/turbopack/index.test.ts
+++ b/test/turbopack/index.test.ts
@@ -25,15 +25,18 @@ import { isDev, isNextGET16 } from '@code-inspector/core';
 
 describe('TurbopackCodeInspectorPlugin', () => {
   const originalRequire = global.require;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/test/project');
     global.require = {
       resolve: vi.fn(() => '/pkg/webpack/index.js'),
     } as any;
   });
 
   afterEach(() => {
+    cwdSpy.mockRestore();
     global.require = originalRequire;
   });
 
@@ -83,6 +86,7 @@ describe('TurbopackCodeInspectorPlugin', () => {
 
       const keys = Object.keys(plugin);
       expect(keys[0]).toBe('**/*.{jsx,tsx,js,ts,mjs,mts}');
+      expect(isNextGET16).toHaveBeenCalledWith('/test/project');
     });
 
     it('should use specific file pattern for Next.js < 16', () => {


### PR DESCRIPTION
## Summary
- Resolve Next.js detection and import lookup from the transformed file directory.
- Update Turbopack integration and generated types/config for the new resolution path.
- Add coverage for Next.js project detection and integration behavior.

## Tests
- Not run in this PR creation step.