### PR TITLE
fix: default turbopack import client to file

### DIFF
--- a/packages/turbopack/src/index.ts
+++ b/packages/turbopack/src/index.ts
@@ -77,23 +77,22 @@ export function TurbopackCodeInspectorPlugin(
   const files = isNextGET16(process.cwd())
     ? '**/*.{jsx,tsx,js,ts,mjs,mts}'
     : matchFiles;
+  const loaderOptions = {
+    ...options,
+    importClient: options.importClient ?? 'file',
+    record,
+  };
 
   return {
     [files]: {
       loaders: [
         {
           loader: `${WebpackDistDir}/loader.js`,
-          options: {
-            ...options,
-            record,
-          },
+          options: loaderOptions,
         },
         {
           loader: `${WebpackDistDir}/inject-loader.js`,
-          options: {
-            ...options,
-            record,
-          },
+          options: loaderOptions,
         },
       ],
     },

--- a/test/turbopack/index.test.ts
+++ b/test/turbopack/index.test.ts
@@ -135,7 +135,24 @@ describe('TurbopackCodeInspectorPlugin', () => {
       const loaderOptions = plugin[key].loaders[0].options;
 
       expect(loaderOptions.escapeTags).toEqual(['div']);
+      expect(loaderOptions.importClient).toBe('file');
       expect(loaderOptions.record).toBeDefined();
+    });
+
+    it('should preserve explicit importClient option', () => {
+      vi.mocked(isDev).mockReturnValueOnce(true);
+      vi.mocked(isNextGET16).mockReturnValueOnce(true);
+
+      const plugin = TurbopackCodeInspectorPlugin({
+        bundler: 'turbopack',
+        output: '/test',
+        importClient: 'code',
+      });
+
+      const key = Object.keys(plugin)[0];
+      const loaderOptions = plugin[key].loaders[0].options;
+
+      expect(loaderOptions.importClient).toBe('code');
     });
   });
 


### PR DESCRIPTION
## Summary
- Set Turbopack loader options to default `importClient` to `file`.
- Preserve an explicit user-provided `importClient` value.
- Add Turbopack plugin tests for the default and explicit override behavior.

## Tests
- `pnpm exec vitest run test/turbopack/index.test.ts`