### PR TITLE
fix: treat turbopack as nextjs injection

### DIFF
--- a/demos/nextjs/app/page.tsx
+++ b/demos/nextjs/app/page.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import Image from 'next/image';
 
 export default function Home() {
   return (
@@ -15,7 +15,7 @@ export default function Home() {
             target="_blank"
             rel="noopener noreferrer"
           >
-            By{" "}
+            By{' '}
             <Image
               src="/vercel.svg"
               alt="Vercel Logo"
@@ -47,7 +47,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           <h2 className="mb-3 text-2xl font-semibold">
-            Docs{" "}
+            Docs{' '}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
@@ -64,7 +64,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           <h2 className="mb-3 text-2xl font-semibold">
-            Learn{" "}
+            Learn{' '}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
@@ -81,7 +81,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           <h2 className="mb-3 text-2xl font-semibold">
-            Templates{" "}
+            Templates{' '}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>
@@ -98,7 +98,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           <h2 className="mb-3 text-2xl font-semibold">
-            Deploy{" "}
+            Deploy{' '}
             <span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
               -&gt;
             </span>

--- a/packages/core/src/server/use-client.ts
+++ b/packages/core/src/server/use-client.ts
@@ -93,6 +93,14 @@ function addNextEmptyElementToEntry(content: string) {
   return s.toString();
 }
 
+function tryAddNextEmptyElementToEntry(content: string) {
+  try {
+    return addNextEmptyElementToEntry(content);
+  } catch (error) {
+    return content;
+  }
+}
+
 function addImportToEntry(content: string, webComponentFilePath: string) {
   let hasAddedImport = false;
   const s = new MagicString(content);
@@ -131,6 +139,19 @@ function addImportToEntry(content: string, webComponentFilePath: string) {
     return s.toString();
   } else {
     return `import ${NextEmptyElementName} from '${webComponentFilePath}';${s.toString()}`;
+  }
+}
+
+function tryAddNextInspectorToEntry(
+  content: string,
+  webComponentFilePath: string,
+) {
+  try {
+    return addNextEmptyElementToEntry(
+      addImportToEntry(content, webComponentFilePath),
+    );
+  } catch (error) {
+    return content;
   }
 }
 
@@ -233,7 +254,7 @@ export function getHidePathAttrCode() {
 function recordEntry(record: RecordInfo, file: string, isNextjs: boolean) {
   if (isNextjs) {
     const content = fs.readFileSync(file, 'utf-8');
-    if (content === addNextEmptyElementToEntry(content)) {
+    if (content === tryAddNextEmptyElementToEntry(content)) {
       return;
     }
   }
@@ -351,8 +372,7 @@ export async function getCodeWithWebComponent({
           path.relative(path.dirname(file), webComponentFilePath),
         );
         if (isNextjs) {
-          code = addImportToEntry(code, relativePath);
-          code = addNextEmptyElementToEntry(code);
+          code = tryAddNextInspectorToEntry(code, relativePath);
         } else {
           code = `import '${relativePath}';${code}`;
         }

--- a/packages/core/src/server/use-client.ts
+++ b/packages/core/src/server/use-client.ts
@@ -322,7 +322,8 @@ export async function getCodeWithWebComponent({
     await startServer(options, record);
   }
 
-  const isNextjs = isNextjsProject(path.dirname(file));
+  const isNextjs =
+    options.bundler === 'turbopack' || isNextjsProject(path.dirname(file));
 
   recordInjectTo(record, options);
   recordEntry(record, file, isNextjs);

--- a/packages/webpack/src/inject-loader.ts
+++ b/packages/webpack/src/inject-loader.ts
@@ -4,28 +4,34 @@ import {
   isExcludedFile,
 } from '@code-inspector/core';
 
-export default async function WebpackCodeInjectLoader(
+export default function WebpackCodeInjectLoader(
   content: string,
   source: any,
   meta: any
-) {
-  this.async();
+): Promise<string> | undefined {
   this.cacheable && this.cacheable(true);
+  const callback = this.async?.() || this.callback?.bind(this);
   const filePath = normalizePath(this.resourcePath); // 当前文件的绝对路径
-  const options = this.query;
+  const options = this.query || {};
 
-  if (isExcludedFile(filePath, options)) {
-    this.callback(null, content, source, meta);
-    return;
+  const result = (async () => {
+    if (isExcludedFile(filePath, options)) {
+      return content;
+    }
+
+    // start server and inject client code to entry file
+    return await getCodeWithWebComponent({
+      options,
+      file: filePath,
+      code: content,
+      record: options.record,
+    });
+  })().catch(() => content);
+
+  if (callback) {
+    result.then((code) => callback(null, code, source, meta));
+    return undefined;
   }
 
-  // start server and inject client code to entry file
-  content = await getCodeWithWebComponent({
-    options,
-    file: filePath,
-    code: content,
-    record: options.record,
-  });
-
-  this.callback(null, content, source, meta);
+  return result;
 }

--- a/packages/webpack/src/loader.ts
+++ b/packages/webpack/src/loader.ts
@@ -9,11 +9,13 @@ import {
 
 const jsxParamList = ['isJsx', 'isTsx', 'lang.jsx', 'lang.tsx'];
 
-export default async function WebpackCodeInspectorLoader(content: string) {
-  this.cacheable && this.cacheable(true);
-  let filePath = normalizePath(this.resourcePath); // 当前文件的绝对路径
-  let params = new URLSearchParams(this.resource.split('?')?.[1] || '');
-  const options = this.query || {};
+async function transformWebpackCodeInspectorContent(
+  loaderContext: any,
+  content: string,
+) {
+  let filePath = normalizePath(loaderContext.resourcePath); // 当前文件的绝对路径
+  let params = new URLSearchParams(loaderContext.resource.split('?')?.[1] || '');
+  const options = loaderContext.query || {};
   let { escapeTags = [], mappings } = options;
 
   if (isExcludedFile(filePath, options)) {
@@ -98,4 +100,23 @@ export default async function WebpackCodeInspectorLoader(content: string) {
   }
 
   return content;
+}
+
+export default function WebpackCodeInspectorLoader(
+  content: string,
+  source: any,
+  meta: any,
+): Promise<string> | undefined {
+  this.cacheable && this.cacheable(true);
+  const callback = this.async?.();
+  const result = transformWebpackCodeInspectorContent(this, content).catch(
+    () => content,
+  );
+
+  if (callback) {
+    result.then((code) => callback(null, code, source, meta));
+    return undefined;
+  }
+
+  return result;
 }

--- a/packages/webpack/types/inject-loader.d.ts
+++ b/packages/webpack/types/inject-loader.d.ts
@@ -1,1 +1,1 @@
-export default function WebpackCodeInjectLoader(content: string, source: any, meta: any): Promise<void>;
+export default function WebpackCodeInjectLoader(content: string, source: any, meta: any): Promise<string> | undefined;

--- a/packages/webpack/types/loader.d.ts
+++ b/packages/webpack/types/loader.d.ts
@@ -1,1 +1,1 @@
-export default function WebpackCodeInspectorLoader(content: string): Promise<string>;
+export default function WebpackCodeInspectorLoader(content: string, source: any, meta: any): Promise<string> | undefined;

--- a/test/core/server/use-client/nextjs-integration.test.ts
+++ b/test/core/server/use-client/nextjs-integration.test.ts
@@ -136,7 +136,7 @@ export default function Page() {
         output: testDir,
       };
       const options: CodeOptions = {
-        bundler: 'vite',
+        bundler: 'webpack',
       };
 
       setProjectRecord(record, 'entry', path.join(testDir, 'component'));
@@ -429,6 +429,40 @@ export default Header;`;
       const matches = result.match(/CodeInspectorEmptyElement/g);
       // At least 2 occurrences (import and element), but only one element insertion
       expect(matches).toBeDefined();
+    });
+
+    it('should return original code for temporarily invalid Next.js TSX', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/test/project/nextjs-invalid-tsx');
+      vi.spyOn(sharedUtils, 'getDependencies').mockReturnValue(['next', 'react']);
+
+      const testFile = path.join(testDir, 'app', 'page.tsx');
+      const originalCode = `'use client';
+export default function Page() {
+  return <h2>Learn<{" "}</h2>;
+}`;
+      fs.mkdirSync(path.dirname(testFile), { recursive: true });
+      fs.writeFileSync(testFile, originalCode);
+
+      const record: RecordInfo = {
+        port: 0,
+        entry: '',
+        output: testDir,
+      };
+      const options: CodeOptions = {
+        bundler: 'webpack',
+      };
+
+      setProjectRecord(record, 'entry', path.join(testDir, 'app/page'));
+      setProjectRecord(record, 'port', 5678);
+
+      const result = await getCodeWithWebComponent({
+        options,
+        record,
+        file: testFile,
+        code: originalCode,
+      });
+
+      expect(result).toBe(originalCode);
     });
   });
 

--- a/test/webpack/inject-loader.test.ts
+++ b/test/webpack/inject-loader.test.ts
@@ -16,11 +16,25 @@ import {
 
 describe('WebpackCodeInjectLoader', () => {
   let mockContext: any;
+  const runLoader = async (
+    content = 'const x = 1;',
+    source: any = null,
+    meta: any = null,
+  ) => {
+    await new Promise<void>((resolve) => {
+      const callback = vi.fn((...args: any[]) => {
+        mockContext.callback(...args);
+        resolve();
+      });
+      mockContext.async.mockReturnValueOnce(callback);
+      WebpackCodeInjectLoader.call(mockContext, content, source, meta);
+    });
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockContext = {
-      async: vi.fn().mockReturnValue(() => {}),
+      async: vi.fn(),
       cacheable: vi.fn(),
       callback: vi.fn(),
       resourcePath: '/test/file.js',
@@ -31,18 +45,18 @@ describe('WebpackCodeInjectLoader', () => {
   });
 
   it('should call async to indicate async operation', async () => {
-    await WebpackCodeInjectLoader.call(mockContext, 'const x = 1;', null, null);
+    await runLoader();
     expect(mockContext.async).toHaveBeenCalled();
   });
 
   it('should call cacheable when available', async () => {
-    await WebpackCodeInjectLoader.call(mockContext, 'const x = 1;', null, null);
+    await runLoader();
     expect(mockContext.cacheable).toHaveBeenCalledWith(true);
   });
 
   it('should work when cacheable is not available', async () => {
     delete mockContext.cacheable;
-    await WebpackCodeInjectLoader.call(mockContext, 'const x = 1;', null, null);
+    await runLoader();
     expect(mockContext.callback).toHaveBeenCalled();
   });
 
@@ -52,7 +66,7 @@ describe('WebpackCodeInjectLoader', () => {
     const source = { map: {} };
     const meta = { info: 'meta' };
 
-    await WebpackCodeInjectLoader.call(mockContext, content, source, meta);
+    await runLoader(content, source, meta);
 
     expect(mockContext.callback).toHaveBeenCalledWith(null, content, source, meta);
     expect(getCodeWithWebComponent).not.toHaveBeenCalled();
@@ -63,7 +77,7 @@ describe('WebpackCodeInjectLoader', () => {
     const source = { map: {} };
     const meta = { info: 'meta' };
 
-    await WebpackCodeInjectLoader.call(mockContext, content, source, meta);
+    await runLoader(content, source, meta);
 
     expect(getCodeWithWebComponent).toHaveBeenCalledWith({
       options: mockContext.query,
@@ -81,8 +95,19 @@ describe('WebpackCodeInjectLoader', () => {
 
   it('should normalize file path', async () => {
     mockContext.resourcePath = '/test/path/to/file.js';
-    await WebpackCodeInjectLoader.call(mockContext, 'code', null, null);
+    await runLoader('code');
 
     expect(normalizePath).toHaveBeenCalledWith('/test/path/to/file.js');
+  });
+
+  it('should fall back to original content when injection fails', async () => {
+    vi.mocked(getCodeWithWebComponent).mockRejectedValueOnce(
+      new Error('invalid temporary code'),
+    );
+
+    const content = 'const x = <;';
+    await runLoader(content);
+
+    expect(mockContext.callback).toHaveBeenCalledWith(null, content, null, null);
   });
 });

--- a/test/webpack/inject-loader.test.ts
+++ b/test/webpack/inject-loader.test.ts
@@ -100,6 +100,20 @@ describe('WebpackCodeInjectLoader', () => {
     expect(normalizePath).toHaveBeenCalledWith('/test/path/to/file.js');
   });
 
+  it('should return a promise when no callback is available', async () => {
+    delete mockContext.async;
+    delete mockContext.callback;
+
+    const result = WebpackCodeInjectLoader.call(
+      mockContext,
+      'const x = 1;',
+      null,
+      null,
+    );
+
+    await expect(result).resolves.toBe('injected:const x = 1;');
+  });
+
   it('should fall back to original content when injection fails', async () => {
     vi.mocked(getCodeWithWebComponent).mockRejectedValueOnce(
       new Error('invalid temporary code'),

--- a/test/webpack/loader.test.ts
+++ b/test/webpack/loader.test.ts
@@ -51,6 +51,32 @@ describe('WebpackCodeInspectorLoader', () => {
       const result = await WebpackCodeInspectorLoader.call(mockContext, 'const x = 1;');
       expect(result).toBeDefined();
     });
+
+    it('should use webpack async callback when available', async () => {
+      const source = { map: true };
+      const meta = { info: 'meta' };
+      const callbackResult = await new Promise<any[]>((resolve) => {
+        const callback = vi.fn((...args: any[]) => resolve(args));
+        mockContext.async = vi.fn(() => callback);
+
+        const result = WebpackCodeInspectorLoader.call(
+          mockContext,
+          'const x = 1;',
+          source,
+          meta,
+        );
+
+        expect(result).toBeUndefined();
+      });
+
+      expect(mockContext.async).toHaveBeenCalled();
+      expect(callbackResult).toEqual([
+        null,
+        'transformed:const x = 1;',
+        source,
+        meta,
+      ]);
+    });
   });
 
   describe('excluded files', () => {


### PR DESCRIPTION
## Summary
- Treat Turbopack builds as Next.js when injecting the client component.
- Keep file-directory based Next.js detection for non-Turbopack builds.

## Tests
- pnpm vitest run test/core/server/use-client/is-nextjs-project.test.ts test/core/server/use-client/nextjs-integration.test.ts