### PR TITLE
feat: optimize inspector tooltip UI to match Chrome DevTools style

### DIFF
--- a/packages/core/src/client/i18n.ts
+++ b/packages/core/src/client/i18n.ts
@@ -73,6 +73,10 @@ const MESSAGES = defineMessages({
     zh: '发送消息失败',
   },
   'settings.modeSettings': { en: 'Mode Settings', zh: '模式设置' },
+  'inspector.clickToOpen': {
+    en: 'Click to open in editor',
+    zh: '点击在编辑器中打开',
+  },
   'tree.clickNodeToLocate': {
     en: 'Click node to locate',
     zh: '点击节点进行定位',

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -621,6 +621,29 @@ export class CodeInspectorComponent extends LitElement {
     return { name, path, line, column };
   };
 
+  // 生成元素选择器的 HTML，格式如 div#myid.class1.class2，带颜色标记
+  getElementSelectorHtml = (target: HTMLElement, tagName: string): TemplateResult => {
+    const parts: TemplateResult[] = [];
+
+    // 标签名
+    parts.push(html`<span class="tag-name">${tagName}</span>`);
+
+    // 添加 id
+    if (target.id) {
+      parts.push(html`<span class="tag-id">#${target.id}</span>`);
+    }
+
+    // 添加 class
+    if (target.className && typeof target.className === 'string') {
+      const classes = target.className.trim().split(/\s+/).filter(Boolean);
+      classes.forEach(cls => {
+        parts.push(html`<span class="tag-class">.${cls}</span>`);
+      });
+    }
+
+    return html`${parts}`;
+  };
+
   removeCover = (force?: boolean | MouseEvent) => {
     if (force !== true && this.nodeTree) {
       return;
@@ -3167,13 +3190,17 @@ export class CodeInspectorComponent extends LitElement {
         })}
         >
           <div class="element-info-content">
-            <div class="name-line">
-              <div class="element-name">
-                <span class="element-title">&lt;${this.element.name}&gt;</span>
+            <div class="inspector-info-header">
+              <div class="element-tag-info">
+                ${this.targetNode ? this.getElementSelectorHtml(this.targetNode, this.element.name) : html`<span class="tag-name">${this.element.name}</span>`}
+              </div>
+              <div class="element-dimensions">
+                ${((this.position.right - this.position.left).toFixed(2))} × ${((this.position.bottom - this.position.top).toFixed(2))}
               </div>
             </div>
-            <div class="path-line">
-              ${this.element.path}:${this.element.line}:${this.element.column}
+            <div class="inspector-info-footer">
+              <div class="inspector-path">${this.element.path}:${this.element.line}:${this.element.column}</div>
+              <div class="inspector-tip">${this.t('inspector.clickToOpen')}</div>
             </div>
           </div>
         </div>
@@ -3493,8 +3520,9 @@ export class CodeInspectorComponent extends LitElement {
       word-break: break-all;
       box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
       box-sizing: border-box;
-      padding: 4px 8px;
-      border-radius: 4px;
+      padding: 6px 8px;
+      border-radius: 2px;
+      font-family: 'PingFang SC', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
     }
     .element-info-top {
       top: -4px;
@@ -3519,14 +3547,58 @@ export class CodeInspectorComponent extends LitElement {
       display: flex;
       justify-content: flex-end;
     }
-    .element-name .element-title {
-      color: coral;
+    .inspector-info-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 20px;
+      line-height: 16px;
+    }
+    .element-tag-info {
+      flex: 1;
+      min-width: 0;
+      overflow-wrap: break-word;
+      word-break: break-all;
       font-weight: bold;
     }
-    .path-line {
-      color: #333;
-      line-height: 12px;
+    .element-tag-name {
+      color: #881280;
+      font-weight: 500;
+    }
+    .tag-name {
+      color: #881280;
+      font-weight: bold;
+    }
+    .tag-id {
+      color: #1a1aa6;
+      font-weight: bold;
+    }
+    .tag-class {
+      color: #c25e00;
+      font-weight: bold;
+    }
+    .element-dimensions {
+      flex-shrink: 0;
+      color: #222;
+      font-weight: 400;
+      white-space: nowrap;
+    }
+    .inspector-info-footer {
       margin-top: 4px;
+      font-size: 11px;
+      overflow-wrap: break-word;
+      word-break: break-all;
+    }
+    .inspector-path {
+      color: #333;
+      line-height: 14px;
+      font-size: 11px;
+    }
+    .inspector-tip {
+      color: #888;
+      line-height: 14px;
+      margin-top: 2px;
+      font-size: 11px;
     }
     .inspector-switch {
       position: fixed;

--- a/packages/core/types/client/i18n.d.ts
+++ b/packages/core/types/client/i18n.d.ts
@@ -93,6 +93,10 @@ declare const MESSAGES: {
         readonly en: "Mode Settings";
         readonly zh: "模式设置";
     };
+    readonly 'inspector.clickToOpen': {
+        readonly en: "Click to open in editor";
+        readonly zh: "点击在编辑器中打开";
+    };
     readonly 'tree.clickNodeToLocate': {
         readonly en: "Click node to locate";
         readonly zh: "点击节点进行定位";

--- a/packages/core/types/client/index.d.ts
+++ b/packages/core/types/client/index.d.ts
@@ -187,6 +187,7 @@ export declare class CodeInspectorComponent extends LitElement {
     }>;
     renderCover: (target: HTMLElement) => Promise<void>;
     getSourceInfo: (target: HTMLElement) => SourceInfo | null;
+    getElementSelectorHtml: (target: HTMLElement, tagName: string) => TemplateResult;
     removeCover: (force?: boolean | MouseEvent) => void;
     renderLayerPanel: (nodeTree: TreeNode, { x, y }: {
         x: number;

--- a/test/core/client/index/render.test.ts
+++ b/test/core/client/index/render.test.ts
@@ -310,8 +310,8 @@ describe('render', () => {
       };
       await component.updateComplete;
 
-      const elementTitle = component.shadowRoot?.querySelector('.element-title');
-      expect(elementTitle?.textContent).toContain('TestComponent');
+      const elementTagInfo = component.shadowRoot?.querySelector('.element-tag-info');
+      expect(elementTagInfo?.textContent).toContain('TestComponent');
     });
 
     it('should render path info', async () => {
@@ -324,8 +324,8 @@ describe('render', () => {
       };
       await component.updateComplete;
 
-      const pathLine = component.shadowRoot?.querySelector('.path-line');
-      expect(pathLine?.textContent).toContain('/src/App.tsx:25:5');
+      const inspectorPath = component.shadowRoot?.querySelector('.inspector-path');
+      expect(inspectorPath?.textContent).toContain('/src/App.tsx:25:5');
     });
   });
 


### PR DESCRIPTION
🎨 Overview
  
  Optimized the inspector tooltip UI to match the Chrome DevTools inspection
  style.

  ✨ Key Changes

  1. Top Layout (Flex Between)

  - Left: Display complete element selector div#id.class1.class2
    - Tag name: purple #881280, bold
    - ID: blue #1a1aa6, bold
    - Class: orange #c25e00, bold
  - Right: Display dimensions 280.50 × 120.75 (2 decimal places)
  - Gap: 20px minimum spacing

  2. Bottom Section

  - File path: /path/to/file.tsx:10:5 (dark gray  `#333`, 11px)
  - Tip text: Click to open in editor / 点击在编辑器中打开 (light gray `#888`, 11px)
    - ✅ i18n support (English & Chinese)

  3. Typography Optimization

  - Main content: 12px (element selector, dimensions)
  - Secondary content: 11px (path, tip)
  - Font priority: PingFang SC → -apple-system → BlinkMacSystemFont
  - Text wrapping: break-all

  📸 Visual Effect

  ┌──────────────────────────────────────┐
  │ div#mydiv.shop        280.50 × 120.75│
  │ /path/to/file.tsx:10:5               │
  │ Click to open in editor              │
  └──────────────────────────────────────┘

  Colors:
  - div - purple #881280, bold
  - #mydiv - blue #1a1aa6, bold
  - .shop - orange #c25e00, bold
  - 280.50 × 120.75 - dark gray `#222`
  - /path/to/file.tsx:10:5 - dark gray `#333`
  - Click to open in editor - light gray `#888`
  
  📁 Modified Files

  - packages/core/src/client/index.ts - Core implementation
  - packages/core/src/client/i18n.ts - Internationalization texts
  - packages/core/types/ - TypeScript type definitions (auto-generated)

  ✅ Compatibility

  - Pure visual optimization, no functional changes
  - Fully backward compatible
  - i18n support for English and Chinese

  🤖 Generated with Claude Code (https://claude.com/claude-code)