### PR TITLE
chore: add docs deploy to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,3 +59,13 @@ jobs:
           else
             pnpm -r --filter "./packages/*" publish --no-git-checks --access public --tag "${{ inputs.dist_tag }}"
           fi
+
+      - name: Install deploy dependencies
+        run: sudo apt-get update && sudo apt-get install -y sshpass
+
+      - name: Deploy docs
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          SERVER_PASSWORD: ${{ secrets.SERVER_PASSWORD }}
+        run: pnpm deploy:docs

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ dist.zip
 .DS_Store
 .idea
 coverage
-deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DEPLOY_HOST:?DEPLOY_HOST is required}"
+: "${DEPLOY_PATH:?DEPLOY_PATH is required}"
+
+deploy_port="${DEPLOY_PORT:-22}"
+ssh_options=(-p "${deploy_port}" -o StrictHostKeyChecking=accept-new)
+scp_options=(-P "${deploy_port}" -o StrictHostKeyChecking=accept-new)
+ssh_cmd=(ssh "${ssh_options[@]}")
+scp_cmd=(scp "${scp_options[@]}")
+
+if [[ -n "${SERVER_PASSWORD:-}" ]]; then
+  if ! command -v sshpass >/dev/null 2>&1; then
+    echo "sshpass is required when SERVER_PASSWORD is set." >&2
+    exit 1
+  fi
+
+  export SSHPASS="${SERVER_PASSWORD}"
+  ssh_cmd=(sshpass -e "${ssh_cmd[@]}")
+  scp_cmd=(sshpass -e "${scp_cmd[@]}")
+fi
+
+remote_path="$(printf '%q' "${DEPLOY_PATH}")"
+
+"${scp_cmd[@]}" ./dist.zip "${DEPLOY_HOST}:${DEPLOY_PATH}/dist.zip"
+"${ssh_cmd[@]}" "${DEPLOY_HOST}" << EOF
+  set -e
+  cd ${remote_path}
+  rm -rf cn en
+  unzip -o dist.zip
+  rm -f dist.zip
+EOF


### PR DESCRIPTION
## Summary
- track deploy.sh and remove it from .gitignore
- read deploy host/path/password from GitHub secrets
- run docs deployment after non-dry-run publish workflow

## Verification
- bash -n deploy.sh
- parsed .github/workflows/publish.yml as YAML