### PR TITLE
feat: improve ai terminal provider compatibility

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,7 +5,10 @@ on:
     branches:
       - main
   pull_request:
-    # 对所有分支的 PR 生效
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   test:
@@ -27,7 +30,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build packages
         run: pnpm build
@@ -38,5 +41,6 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: zh-lx/code-inspector
+          use_oidc: true
+          fail_ci_if_error: true
+          verbose: true

--- a/demos/vite-vue3/vite.config.ts
+++ b/demos/vite-vue3/vite.config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
             //   models: ['gpt-5.2'],
             // },
           },
+          // opencode: {
+          //   type: 'terminal',
+          // },
         },
       },
       // pathFormat: ['-g', '-r', '{file}:{line}:{column}']

--- a/packages/core/src/client/ai-terminal.ts
+++ b/packages/core/src/client/ai-terminal.ts
@@ -5,7 +5,6 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import type { ITheme } from '@xterm/xterm';
 import type { ChatProvider } from './ai';
 
-
 const XTERM_CSS = `
 .xterm {
   height: 100%;
@@ -82,7 +81,6 @@ const XTERM_CSS = `
 }
 `;
 
-
 const DARK_THEME: ITheme = {
   background: '#2e3440',
   foreground: '#d8dee9',
@@ -146,8 +144,7 @@ function terminalBackgroundFor(theme: 'dark' | 'light'): string {
 
 function terminalCursorFor(theme: 'dark' | 'light'): string {
   return (
-    terminalThemeFor(theme).cursor ||
-    (theme === 'dark' ? '#88c0d0' : '#5e81ac')
+    terminalThemeFor(theme).cursor || (theme === 'dark' ? '#88c0d0' : '#5e81ac')
   );
 }
 
@@ -161,15 +158,7 @@ const MAX_TERMINAL_REPLAY_BUFFER = 500_000;
 const DEFAULT_TERMINAL_OVERVIEW_RULER_WIDTH = 10;
 const MINIMUM_TERMINAL_COLS = 2;
 const MINIMUM_TERMINAL_ROWS = 1;
-const DARK_ANSI_COLOR_INDICES = new Set([
-  0,
-  232,
-  233,
-  234,
-  235,
-  236,
-  237,
-]);
+const DARK_ANSI_COLOR_INDICES = new Set([0, 232, 233, 234, 235, 236, 237]);
 const LIGHT_ANSI_COLOR_INDICES = new Set([15, 231, 252, 253, 254, 255]);
 
 function isDarkRgb(r: number, g: number, b: number): boolean {
@@ -340,7 +329,6 @@ function normalizeTerminalOutputForTheme(
   );
 }
 
-
 interface TerminalCreateMessage {
   type: 'create';
   provider: ChatProvider;
@@ -398,7 +386,6 @@ type ServerMessage =
   | ServerErrorMessage
   | ServerSessionMessage
   | ServerRuntimeStateMessage;
-
 
 export class AITerminalManager {
   private terminal: Terminal | null = null;
@@ -515,8 +502,7 @@ export class AITerminalManager {
       }
     };
 
-    this.ws.onclose = () => {
-    };
+    this.ws.onclose = () => {};
 
     this.ws.onerror = () => {
       this.onError?.('WebSocket connection failed');
@@ -549,10 +535,8 @@ export class AITerminalManager {
         };
         this.ws.send(JSON.stringify(msg));
       }
-    } catch {
-    }
+    } catch {}
   }
-
 
   private proposeDimensions(): { cols: number; rows: number } | null {
     if (!this.terminal || !this.container) return null;
@@ -563,7 +547,11 @@ export class AITerminalManager {
     const renderDimensions = (this.terminal as any)?._core?._renderService
       ?.dimensions;
 
-    if (!terminalElement || !terminalElement.parentElement || !renderDimensions) {
+    if (
+      !terminalElement ||
+      !terminalElement.parentElement ||
+      !renderDimensions
+    ) {
       return null;
     }
 
@@ -668,7 +656,6 @@ export class AITerminalManager {
     }
   }
 
-
   private rememberOutput(data: string): void {
     if (!data) return;
 
@@ -700,8 +687,7 @@ export class AITerminalManager {
     if (this.ws) {
       try {
         this.ws.close();
-      } catch {
-      }
+      } catch {}
       this.ws = null;
     }
   }
@@ -725,8 +711,10 @@ export class AITerminalManager {
     return this._disposed;
   }
 
-
-  private attachTerminal(container: HTMLElement, theme: 'dark' | 'light'): void {
+  private attachTerminal(
+    container: HTMLElement,
+    theme: 'dark' | 'light',
+  ): void {
     this.container = container;
     this.currentTheme = theme;
     this.container.style.backgroundColor = terminalBackgroundFor(theme);
@@ -739,7 +727,7 @@ export class AITerminalManager {
       fontSize: 13,
       fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace",
       theme: terminalThemeFor(theme),
-      minimumContrastRatio: 4.5,
+      minimumContrastRatio: 1,
       overviewRuler: { width: this.getOverviewRulerWidth() },
       allowProposedApi: true,
       scrollback: 5000,
@@ -812,4 +800,3 @@ export async function checkTerminalAvailable(
     return false;
   }
 }
-

--- a/packages/core/src/client/ai-terminal.ts
+++ b/packages/core/src/client/ai-terminal.ts
@@ -541,7 +541,7 @@ export class AITerminalManager {
       ) {
         this.terminal.resize(dims.cols, dims.rows);
       }
-      if (dims && this.ws && this.ws.readyState === WebSocket.OPEN) {
+      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
         const msg: TerminalResizeMessage = {
           type: 'resize',
           cols: dims.cols,

--- a/packages/core/src/client/ai-terminal.ts
+++ b/packages/core/src/client/ai-terminal.ts
@@ -1,20 +1,11 @@
-/**
- * 客户端终端模块 - 基于 @xterm/xterm 提供浏览器内原生终端体验
- */
+/** Browser terminal manager built on xterm.js. */
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import type { ITheme } from '@xterm/xterm';
 import type { ChatProvider } from './ai';
 
-// ============================================================================
-// xterm CSS（内联注入 Shadow DOM）
-// ============================================================================
 
-/**
- * xterm.js 核心 CSS - 从 @xterm/xterm/css/xterm.css 提取的必要样式
- * 在 Shadow DOM 中需要手动注入，因为外部 CSS 无法穿透 shadow boundary
- */
 const XTERM_CSS = `
 .xterm {
   height: 100%;
@@ -71,91 +62,284 @@ const XTERM_CSS = `
 .xterm-screen .xterm-decoration-container .xterm-decoration { z-index: 6; position: absolute; }
 .xterm-screen .xterm-decoration-container .xterm-decoration.xterm-decoration-top-layer { z-index: 7; }
 .xterm-decoration-overview-ruler {
-  z-index: 8; position: absolute; top: 0; right: 0; pointer-events: none;
+  position: absolute; top: 0; right: 0; pointer-events: none;
 }
 .xterm-decoration-top { z-index: 2; position: relative; }
 
-/* ----------------------------------------------------------------------------
- * xterm v6 自定义滚动条（派生自 VS Code ScrollableElement）
- * 真实滚动条是 .xterm-scrollable-element > .scrollbar > .slider，宽度由 xterm
- * 以内联样式写死为 14px（overviewRuler.width || 14），又粗又显眼。
- * 由于项目未引入官方 xterm.css，这里补齐滚动条的显隐过渡，并把它收窄美化。
- * 滑块颜色仍由 xterm 按主题动态注入（含 normal/hover/active 三态），无需在此设置。
- * -------------------------------------------------------------------------- */
 .xterm .xterm-scrollable-element > .scrollbar { cursor: default; }
-/* 空闲淡出 / 滚动·悬停时淡入（xterm 通过 toggle visible/invisible class 控制）*/
-.xterm .xterm-scrollable-element > .visible {
-  opacity: 1; background: rgba(0, 0, 0, 0);
-  transition: opacity 100ms linear; z-index: 11;
-}
-.xterm .xterm-scrollable-element > .invisible { opacity: 0; pointer-events: none; }
-.xterm .xterm-scrollable-element > .invisible.fade { transition: opacity 800ms linear; }
-/* 收窄：垂直 14px→8px、水平同步；!important 覆盖 xterm 写在元素上的内联宽高 */
 .xterm .xterm-scrollable-element > .scrollbar.vertical,
 .xterm .xterm-scrollable-element > .scrollbar.vertical > .slider { width: 8px !important; }
 .xterm .xterm-scrollable-element > .scrollbar.horizontal,
 .xterm .xterm-scrollable-element > .scrollbar.horizontal > .slider { height: 8px !important; }
-/* 圆角胶囊滑块 */
 .xterm .xterm-scrollable-element > .scrollbar > .slider { border-radius: 4px; }
+
+[data-terminal-provider="opencode"] .xterm .xterm-scrollable-element > .scrollbar.vertical > .slider { width: 0px !important; }
+[data-terminal-provider="opencode"] .xterm .xterm-scrollable-element { height: 100% !important; bottom: 0 !important; }
+[data-terminal-provider="opencode"] .xterm .xterm-scrollable-element > .scrollbar.horizontal,
+[data-terminal-provider="opencode"] .xterm .xterm-scrollable-element > .scrollbar.horizontal > .slider {
+  height: 0px !important;
+  display: none !important;
+}
 `;
 
-// ============================================================================
-// 终端主题
-// ============================================================================
 
 const DARK_THEME: ITheme = {
-  background: '#1e1e1e',
-  foreground: '#d4d4d4',
-  cursor: '#d4d4d4',
-  cursorAccent: '#1e1e1e',
-  selectionBackground: '#264f78',
+  background: '#2e3440',
+  foreground: '#d8dee9',
+  cursor: '#88c0d0',
+  cursorAccent: '#2e3440',
+  selectionBackground: '#4c566a',
   selectionForeground: '#ffffff',
-  black: '#000000',
-  red: '#cd3131',
-  green: '#0dbc79',
-  yellow: '#e5e510',
-  blue: '#2472c8',
-  magenta: '#bc3fbc',
-  cyan: '#11a8cd',
-  white: '#e5e5e5',
-  brightBlack: '#666666',
-  brightRed: '#f14c4c',
-  brightGreen: '#23d18b',
-  brightYellow: '#f5f543',
-  brightBlue: '#3b8eea',
-  brightMagenta: '#d670d6',
-  brightCyan: '#29b8db',
-  brightWhite: '#e5e5e5',
+  black: '#3b4252',
+  red: '#bf616a',
+  green: '#a3be8c',
+  yellow: '#ebcb8b',
+  blue: '#81a1c1',
+  magenta: '#b48ead',
+  cyan: '#88c0d0',
+  white: '#e5e9f0',
+  brightBlack: '#4c566a',
+  brightRed: '#d08770',
+  brightGreen: '#a3be8c',
+  brightYellow: '#ebcb8b',
+  brightBlue: '#81a1c1',
+  brightMagenta: '#b48ead',
+  brightCyan: '#8fbcbb',
+  brightWhite: '#ffffff',
 };
 
 const LIGHT_THEME: ITheme = {
-  background: '#ffffff',
-  foreground: '#1e1e1e',
-  cursor: '#1e1e1e',
-  cursorAccent: '#ffffff',
-  selectionBackground: '#add6ff',
+  background: '#eceff4',
+  foreground: '#2e3440',
+  cursor: '#5e81ac',
+  cursorAccent: '#eceff4',
+  selectionBackground: '#d8dee9',
   selectionForeground: '#000000',
-  black: '#000000',
-  red: '#cd3131',
-  green: '#00bc00',
-  yellow: '#949800',
-  blue: '#0451a5',
-  magenta: '#bc05bc',
-  cyan: '#0598bc',
-  white: '#555555',
-  brightBlack: '#666666',
-  brightRed: '#cd3131',
-  brightGreen: '#14ce14',
-  brightYellow: '#b5ba00',
-  brightBlue: '#0451a5',
-  brightMagenta: '#bc05bc',
-  brightCyan: '#0598bc',
-  brightWhite: '#a5a5a5',
+  black: '#3b4252',
+  red: '#a34b5c',
+  green: '#5f7a60',
+  yellow: '#8f6f3e',
+  blue: '#4c6f97',
+  magenta: '#8a5d83',
+  cyan: '#4f8a94',
+  white: '#7b88a1',
+  brightBlack: '#4c566a',
+  brightRed: '#8f3f4f',
+  brightGreen: '#4f6b53',
+  brightYellow: '#7a5f33',
+  brightBlue: '#3f5f84',
+  brightMagenta: '#744c70',
+  brightCyan: '#3f727b',
+  brightWhite: '#d8dee9',
 };
 
-// ============================================================================
-// WebSocket 通信协议（与服务端对应）
-// ============================================================================
+function terminalThemeFor(theme: 'dark' | 'light'): ITheme {
+  return theme === 'dark' ? DARK_THEME : LIGHT_THEME;
+}
+
+function terminalBackgroundFor(theme: 'dark' | 'light'): string {
+  return (
+    terminalThemeFor(theme).background ||
+    (theme === 'dark' ? '#2e3440' : '#eceff4')
+  );
+}
+
+function terminalCursorFor(theme: 'dark' | 'light'): string {
+  return (
+    terminalThemeFor(theme).cursor ||
+    (theme === 'dark' ? '#88c0d0' : '#5e81ac')
+  );
+}
+
+const LIGHT_SURFACE_BACKGROUND_RGB = [236, 239, 244] as const;
+const LIGHT_FOREGROUND_RGB = [46, 52, 64] as const;
+const DARK_SURFACE_BACKGROUND_RGB = [46, 52, 64] as const;
+const DARK_FOREGROUND_RGB = [216, 222, 233] as const;
+const DARK_BACKGROUND_THRESHOLD = 64;
+const LIGHT_BACKGROUND_THRESHOLD = 200;
+const MAX_TERMINAL_REPLAY_BUFFER = 500_000;
+const DEFAULT_TERMINAL_OVERVIEW_RULER_WIDTH = 10;
+const MINIMUM_TERMINAL_COLS = 2;
+const MINIMUM_TERMINAL_ROWS = 1;
+const DARK_ANSI_COLOR_INDICES = new Set([
+  0,
+  232,
+  233,
+  234,
+  235,
+  236,
+  237,
+]);
+const LIGHT_ANSI_COLOR_INDICES = new Set([15, 231, 252, 253, 254, 255]);
+
+function isDarkRgb(r: number, g: number, b: number): boolean {
+  return (
+    Number.isFinite(r) &&
+    Number.isFinite(g) &&
+    Number.isFinite(b) &&
+    r <= DARK_BACKGROUND_THRESHOLD &&
+    g <= DARK_BACKGROUND_THRESHOLD &&
+    b <= DARK_BACKGROUND_THRESHOLD
+  );
+}
+
+function isLightRgb(r: number, g: number, b: number): boolean {
+  return (
+    Number.isFinite(r) &&
+    Number.isFinite(g) &&
+    Number.isFinite(b) &&
+    r >= LIGHT_BACKGROUND_THRESHOLD &&
+    g >= LIGHT_BACKGROUND_THRESHOLD &&
+    b >= LIGHT_BACKGROUND_THRESHOLD
+  );
+}
+
+function rgbSgrParams(
+  kind: 'foreground' | 'background',
+  rgb: readonly number[],
+): string[] {
+  const [r, g, b] = rgb;
+  return [
+    kind === 'foreground' ? '38' : '48',
+    '2',
+    String(r),
+    String(g),
+    String(b),
+  ];
+}
+
+function themedForegroundParams(theme: 'dark' | 'light'): string[] {
+  return rgbSgrParams(
+    'foreground',
+    theme === 'light' ? LIGHT_FOREGROUND_RGB : DARK_FOREGROUND_RGB,
+  );
+}
+
+function themedBackgroundParams(theme: 'dark' | 'light'): string[] {
+  return rgbSgrParams(
+    'background',
+    theme === 'light'
+      ? LIGHT_SURFACE_BACKGROUND_RGB
+      : DARK_SURFACE_BACKGROUND_RGB,
+  );
+}
+
+function normalizeTerminalSgr(
+  paramsText: string,
+  theme: 'dark' | 'light',
+): string {
+  if (!paramsText) return paramsText;
+
+  const params = paramsText.split(';');
+  const normalized: string[] = [];
+
+  for (let i = 0; i < params.length; i += 1) {
+    const param = params[i];
+
+    if (theme === 'light' && (param === '37' || param === '97')) {
+      normalized.push(...themedForegroundParams(theme));
+      continue;
+    }
+
+    if (theme === 'dark' && (param === '30' || param === '90')) {
+      normalized.push(...themedForegroundParams(theme));
+      continue;
+    }
+
+    if (theme === 'light' && (param === '40' || param === '100')) {
+      normalized.push(...themedBackgroundParams(theme));
+      continue;
+    }
+
+    if (theme === 'dark' && (param === '47' || param === '107')) {
+      normalized.push(...themedBackgroundParams(theme));
+      continue;
+    }
+
+    if (param === '38' && params[i + 1] === '2') {
+      const r = Number(params[i + 2]);
+      const g = Number(params[i + 3]);
+      const b = Number(params[i + 4]);
+      if (
+        (theme === 'light' && isLightRgb(r, g, b)) ||
+        (theme === 'dark' && isDarkRgb(r, g, b))
+      ) {
+        normalized.push(...themedForegroundParams(theme));
+        i += 4;
+        continue;
+      }
+    }
+
+    if (param === '38' && params[i + 1] === '5') {
+      const colorIndex = Number(params[i + 2]);
+      if (
+        (theme === 'light' && LIGHT_ANSI_COLOR_INDICES.has(colorIndex)) ||
+        (theme === 'dark' && DARK_ANSI_COLOR_INDICES.has(colorIndex))
+      ) {
+        normalized.push(...themedForegroundParams(theme));
+        i += 2;
+        continue;
+      }
+    }
+
+    if (param === '48' && params[i + 1] === '2') {
+      const r = Number(params[i + 2]);
+      const g = Number(params[i + 3]);
+      const b = Number(params[i + 4]);
+      if (
+        (theme === 'light' && isDarkRgb(r, g, b)) ||
+        (theme === 'dark' && isLightRgb(r, g, b))
+      ) {
+        normalized.push(...themedBackgroundParams(theme));
+        i += 4;
+        continue;
+      }
+    }
+
+    if (param === '48' && params[i + 1] === '5') {
+      const colorIndex = Number(params[i + 2]);
+      if (
+        (theme === 'light' && DARK_ANSI_COLOR_INDICES.has(colorIndex)) ||
+        (theme === 'dark' && LIGHT_ANSI_COLOR_INDICES.has(colorIndex))
+      ) {
+        normalized.push(...themedBackgroundParams(theme));
+        i += 2;
+        continue;
+      }
+    }
+
+    normalized.push(param);
+  }
+
+  return normalized.join(';');
+}
+
+function normalizeTerminalOutputForTheme(
+  data: string,
+  theme: 'dark' | 'light',
+): string {
+  const normalizedSgr = data.replace(
+    /\x1b\[([0-9;]*)m/g,
+    (match, paramsText: string) => {
+      const normalizedParams = normalizeTerminalSgr(paramsText, theme);
+      return normalizedParams === paramsText
+        ? match
+        : `\x1b[${normalizedParams}m`;
+    },
+  );
+
+  return normalizedSgr.replace(
+    /\x1b\]12;([^\x07\x1b\x9c]*)(\x07|\x1b\\|\x9c)/g,
+    (match, cursorColor: string, terminator: string) => {
+      if (!cursorColor.trim() || cursorColor.trim() === '?') {
+        return match;
+      }
+
+      return `\x1b]12;${terminalCursorFor(theme)}${terminator}`;
+    },
+  );
+}
+
 
 interface TerminalCreateMessage {
   type: 'create';
@@ -215,9 +399,6 @@ type ServerMessage =
   | ServerSessionMessage
   | ServerRuntimeStateMessage;
 
-// ============================================================================
-// AITerminalManager
-// ============================================================================
 
 export class AITerminalManager {
   private terminal: Terminal | null = null;
@@ -228,14 +409,14 @@ export class AITerminalManager {
   private resizeObserver: ResizeObserver | null = null;
   private styleElement: HTMLStyleElement | null = null;
   private _disposed = false;
+  private currentTheme: 'dark' | 'light' = 'dark';
+  private currentProvider: ChatProvider = 'claudeCode';
+  private outputHistory: string[] = [];
+  private outputHistoryLength = 0;
 
-  /** 进程退出回调 */
   onExit?: (code: number) => void;
-  /** 错误回调 */
   onError?: (message: string) => void;
-  /** 运行时会话 ID 回调 */
   onRuntimeSession?: (runtimeSessionId: string, kind?: string) => void;
-  /** 运行时游标回调 */
   onRuntimeCursor?: (cursor: number) => void;
 
   constructor(
@@ -243,19 +424,24 @@ export class AITerminalManager {
     private port: number,
   ) {}
 
-  /**
-   * 将终端挂载到 DOM 容器
-   */
-  mount(container: HTMLElement, theme: 'dark' | 'light'): void {
+  mount(
+    container: HTMLElement,
+    theme: 'dark' | 'light',
+    provider: ChatProvider = this.currentProvider,
+  ): void {
+    this.currentProvider = provider;
     this.attachTerminal(container, theme);
   }
 
-  /**
-   * 当弹窗容器被卸载后，重新将终端挂载到新的 DOM 容器
-   */
-  remount(container: HTMLElement, theme: 'dark' | 'light'): void {
+  remount(
+    container: HTMLElement,
+    theme: 'dark' | 'light',
+    provider: ChatProvider = this.currentProvider,
+  ): void {
     if (this._disposed) return;
+    this.currentProvider = provider;
     if (this.container === container && this.terminal) {
+      this.applyProviderLayout();
       this.setTheme(theme);
       this.fit();
       return;
@@ -265,9 +451,6 @@ export class AITerminalManager {
     this.attachTerminal(container, theme);
   }
 
-  /**
-   * 连接 WebSocket 并创建终端会话
-   */
   connect(options: {
     provider: ChatProvider;
     prompt?: string;
@@ -277,8 +460,10 @@ export class AITerminalManager {
     cwd: string;
     model?: string;
   }): void {
-    // 关闭已有连接
     this.closeWebSocket();
+    this.clearOutputHistory();
+    this.currentProvider = options.provider;
+    this.applyProviderLayout();
 
     const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const wsUrl = `${protocol}//${this.ip}:${this.port}/ai/terminal`;
@@ -298,7 +483,6 @@ export class AITerminalManager {
       };
       this.ws!.send(JSON.stringify(createMsg));
 
-      // 连接建立后发送当前终端尺寸
       if (this.fitAddon && this.terminal) {
         this.fit();
       }
@@ -313,11 +497,11 @@ export class AITerminalManager {
       }
 
       if (msg.type === 'output') {
-        this.terminal?.write(msg.data);
+        this.write(msg.data);
       } else if (msg.type === 'exit') {
         this.onExit?.(msg.code);
       } else if (msg.type === 'error') {
-        this.terminal?.write(`\r\n\x1b[31m${msg.message}\x1b[0m\r\n`);
+        this.write(`\r\n\x1b[31m${msg.message}\x1b[0m\r\n`);
         this.onError?.(msg.message);
       } else if (msg.type === 'runtime_session') {
         this.onRuntimeSession?.(msg.runtimeSessionId, msg.runtimeKind);
@@ -332,7 +516,6 @@ export class AITerminalManager {
     };
 
     this.ws.onclose = () => {
-      // 连接关闭不一定是错误，可能是进程正常退出
     };
 
     this.ws.onerror = () => {
@@ -340,9 +523,6 @@ export class AITerminalManager {
     };
   }
 
-  /**
-   * 发送用户输入到 PTY
-   */
   sendInput(data: string): void {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       const msg: TerminalInputMessage = { type: 'input', data };
@@ -350,15 +530,17 @@ export class AITerminalManager {
     }
   }
 
-  /**
-   * 自适应终端尺寸
-   */
   fit(): void {
     if (!this.fitAddon || !this.terminal || !this.container) return;
     try {
-      this.fitAddon.fit();
-      // 同步新尺寸到服务端
-      const dims = this.fitAddon.proposeDimensions();
+      const dims = this.proposeDimensions();
+      if (!dims) return;
+      if (
+        this.terminal.cols !== dims.cols ||
+        this.terminal.rows !== dims.rows
+      ) {
+        this.terminal.resize(dims.cols, dims.rows);
+      }
       if (dims && this.ws && this.ws.readyState === WebSocket.OPEN) {
         const msg: TerminalResizeMessage = {
           type: 'resize',
@@ -368,61 +550,162 @@ export class AITerminalManager {
         this.ws.send(JSON.stringify(msg));
       }
     } catch {
-      // 容器可能还没有尺寸
     }
   }
 
-  /**
-   * 切换终端主题
-   */
+
+  private proposeDimensions(): { cols: number; rows: number } | null {
+    if (!this.terminal || !this.container) return null;
+
+    const terminalElement = (this.terminal as any).element as
+      | HTMLElement
+      | undefined;
+    const renderDimensions = (this.terminal as any)?._core?._renderService
+      ?.dimensions;
+
+    if (!terminalElement || !terminalElement.parentElement || !renderDimensions) {
+      return null;
+    }
+
+    const cellWidth = renderDimensions.css?.cell?.width;
+    const cellHeight = renderDimensions.css?.cell?.height;
+    if (!cellWidth || !cellHeight) {
+      return null;
+    }
+
+    const parentElementStyle = window.getComputedStyle(
+      terminalElement.parentElement,
+    );
+    const parentElementHeight = Math.max(
+      0,
+      parseInt(parentElementStyle.getPropertyValue('height')) || 0,
+    );
+    const parentElementWidth = Math.max(
+      0,
+      parseInt(parentElementStyle.getPropertyValue('width')) || 0,
+    );
+    const elementStyle = window.getComputedStyle(terminalElement);
+    const elementPaddingTop =
+      parseInt(elementStyle.getPropertyValue('padding-top')) || 0;
+    const elementPaddingBottom =
+      parseInt(elementStyle.getPropertyValue('padding-bottom')) || 0;
+    const elementPaddingRight =
+      parseInt(elementStyle.getPropertyValue('padding-right')) || 0;
+    const elementPaddingLeft =
+      parseInt(elementStyle.getPropertyValue('padding-left')) || 0;
+    const elementPaddingVer = elementPaddingTop + elementPaddingBottom;
+    const elementPaddingHor = elementPaddingRight + elementPaddingLeft;
+    const scrollbarWidth =
+      this.terminal.options.scrollback === 0 ? 0 : this.getOverviewRulerWidth();
+    const availableHeight = parentElementHeight - elementPaddingVer;
+    const availableWidth =
+      parentElementWidth - elementPaddingHor - scrollbarWidth;
+
+    return {
+      cols: Math.max(
+        MINIMUM_TERMINAL_COLS,
+        Math.floor(availableWidth / cellWidth),
+      ),
+      rows: Math.max(
+        MINIMUM_TERMINAL_ROWS,
+        Math.floor(availableHeight / cellHeight),
+      ),
+    };
+  }
   setTheme(theme: 'dark' | 'light'): void {
+    const shouldReplayOutput = this.currentTheme !== theme;
+    this.currentTheme = theme;
     if (this.container) {
-      this.container.style.backgroundColor =
-        theme === 'dark' ? DARK_THEME.background || '#1e1e1e' : LIGHT_THEME.background || '#ffffff';
+      this.container.style.backgroundColor = terminalBackgroundFor(theme);
     }
     if (this.terminal) {
-      this.terminal.options.theme = theme === 'dark' ? DARK_THEME : LIGHT_THEME;
+      this.terminal.options.theme = terminalThemeFor(theme);
+      if (shouldReplayOutput) {
+        this.replayOutputHistory();
+      }
     }
   }
 
-  /**
-   * 聚焦终端
-   */
   focus(): void {
     this.terminal?.focus();
   }
 
-  /**
-   * 清空终端内容
-   */
   clear(): void {
     this.terminal?.clear();
+    this.clearOutputHistory();
   }
 
-  /**
-   * 写入内容到终端（本地，不通过 WebSocket）
-   */
   write(data: string): void {
-    this.terminal?.write(data);
+    this.rememberOutput(data);
+    this.renderOutput(data);
   }
 
-  /**
-   * 关闭 WebSocket 连接（服务端会自动 kill PTY）
-   */
+  private renderOutput(data: string): void {
+    this.terminal?.write(
+      this.currentProvider === 'opencode' || this.currentProvider === 'codex'
+        ? data
+        : normalizeTerminalOutputForTheme(data, this.currentTheme),
+    );
+  }
+
+  private getOverviewRulerWidth(): number {
+    return this.currentProvider === 'opencode'
+      ? 0
+      : DEFAULT_TERMINAL_OVERVIEW_RULER_WIDTH;
+  }
+
+  private applyProviderLayout(): void {
+    if (this.container) {
+      this.container.dataset.terminalProvider = this.currentProvider;
+    }
+    if (this.terminal) {
+      this.terminal.options.overviewRuler = {
+        width: this.getOverviewRulerWidth(),
+      };
+      if (this.fitAddon && this.container) {
+        this.fit();
+      }
+    }
+  }
+
+
+  private rememberOutput(data: string): void {
+    if (!data) return;
+
+    this.outputHistory.push(data);
+    this.outputHistoryLength += data.length;
+
+    while (
+      this.outputHistoryLength > MAX_TERMINAL_REPLAY_BUFFER &&
+      this.outputHistory.length > 1
+    ) {
+      const removed = this.outputHistory.shift();
+      this.outputHistoryLength -= removed?.length || 0;
+    }
+  }
+
+  private clearOutputHistory(): void {
+    this.outputHistory = [];
+    this.outputHistoryLength = 0;
+  }
+
+  private replayOutputHistory(): void {
+    if (!this.terminal || this.outputHistory.length === 0) return;
+
+    this.terminal.reset();
+    this.renderOutput(this.outputHistory.join(''));
+  }
+
   closeWebSocket(): void {
     if (this.ws) {
       try {
         this.ws.close();
       } catch {
-        // ignore
       }
       this.ws = null;
     }
   }
 
-  /**
-   * 完全销毁：释放终端、WebSocket、ResizeObserver
-   */
   dispose(): void {
     if (this._disposed) return;
     this._disposed = true;
@@ -438,64 +721,52 @@ export class AITerminalManager {
     this.container = null;
   }
 
-  /**
-   * 是否已销毁
-   */
   isDisposed(): boolean {
     return this._disposed;
   }
 
-  // --------------------------------------------------------------------------
-  // 私有方法
-  // --------------------------------------------------------------------------
 
   private attachTerminal(container: HTMLElement, theme: 'dark' | 'light'): void {
     this.container = container;
-    this.container.style.backgroundColor =
-      theme === 'dark' ? DARK_THEME.background || '#1e1e1e' : LIGHT_THEME.background || '#ffffff';
+    this.currentTheme = theme;
+    this.container.style.backgroundColor = terminalBackgroundFor(theme);
+    this.container.dataset.terminalProvider = this.currentProvider;
 
-    // 注入 xterm CSS 到 shadow root（或 document）
     this.injectCSS(container);
 
-    // 创建终端实例
     this.terminal = new Terminal({
       cursorBlink: true,
       fontSize: 13,
       fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace",
-      theme: theme === 'dark' ? DARK_THEME : LIGHT_THEME,
+      theme: terminalThemeFor(theme),
+      minimumContrastRatio: 4.5,
+      overviewRuler: { width: this.getOverviewRulerWidth() },
       allowProposedApi: true,
       scrollback: 5000,
     });
 
-    // 加载插件
     this.fitAddon = new FitAddon();
     this.webLinksAddon = new WebLinksAddon();
     this.terminal.loadAddon(this.fitAddon);
     this.terminal.loadAddon(this.webLinksAddon);
 
-    // 挂载到 DOM
     this.terminal.open(container);
+    this.applyProviderLayout();
 
-    // 延迟 fit 以确保容器有尺寸
     requestAnimationFrame(() => {
       this.fit();
     });
 
-    // 监听容器 resize
     this.resizeObserver = new ResizeObserver(() => {
       this.fit();
     });
     this.resizeObserver.observe(container);
 
-    // 终端输入 → WebSocket
     this.terminal.onData((data: string) => {
       this.sendInput(data);
     });
   }
 
-  /**
-   * 释放当前挂载的 xterm 实例，但保留 WebSocket 连接
-   */
   private detachTerminal(): void {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
@@ -512,13 +783,8 @@ export class AITerminalManager {
     this.container = null;
   }
 
-  // --------------------------------------------------------------------------
-  /**
-   * 将 xterm CSS 注入到容器所在的 shadow root 或 document
-   */
   private injectCSS(container: HTMLElement): void {
     const root = container.getRootNode() as ShadowRoot | Document;
-    // 检查是否已注入
     if (root.querySelector?.('style[data-xterm-css]')) return;
 
     this.styleElement = document.createElement('style');
@@ -533,9 +799,6 @@ export class AITerminalManager {
   }
 }
 
-/**
- * 检查服务端终端功能是否可用
- */
 export async function checkTerminalAvailable(
   ip: string,
   port: number,
@@ -549,3 +812,4 @@ export async function checkTerminalAvailable(
     return false;
   }
 }
+

--- a/packages/core/src/client/ai-terminal.ts
+++ b/packages/core/src/client/ai-terminal.ts
@@ -727,7 +727,7 @@ export class AITerminalManager {
       fontSize: 13,
       fontFamily: "'Menlo', 'Monaco', 'Courier New', monospace",
       theme: terminalThemeFor(theme),
-      minimumContrastRatio: 1,
+      minimumContrastRatio: 1.8,
       overviewRuler: { width: this.getOverviewRulerWidth() },
       allowProposedApi: true,
       scrollback: 5000,

--- a/packages/core/src/client/ai-terminal.ts
+++ b/packages/core/src/client/ai-terminal.ts
@@ -642,7 +642,7 @@ export class AITerminalManager {
 
   private renderOutput(data: string): void {
     this.terminal?.write(
-      this.currentProvider === 'opencode' || this.currentProvider === 'codex'
+      this.currentProvider === 'opencode'
         ? data
         : normalizeTerminalOutputForTheme(data, this.currentTheme),
     );

--- a/packages/core/src/client/ai.ts
+++ b/packages/core/src/client/ai.ts
@@ -3248,15 +3248,11 @@ export const chatStyles = css`
     flex-direction: column;
   }
 
-  .chat-terminal-container[data-terminal-provider="opencode"] {
+  .chat-terminal-container[data-terminal-provider='opencode'] {
     padding: 0;
   }
 
-  .chat-terminal-container .xterm-rows {
-    padding: 4px 0 0 4px;
-  }
-
-  .chat-terminal-container[data-terminal-provider="opencode"] .xterm-rows {
+  .chat-terminal-container[data-terminal-provider='opencode'] .xterm-rows {
     padding: 0;
   }
 

--- a/packages/core/src/client/ai.ts
+++ b/packages/core/src/client/ai.ts
@@ -1924,100 +1924,100 @@ export function renderChatModal(
 export const chatStyles = css`
   /* 暗色主题变量（默认） */
   :host {
-    --chat-bg: #1e1e1e;
-    --chat-header-bg: #252526;
-    --chat-border: #333;
-    --chat-text: #d4d4d4;
-    --chat-text-primary: #d4d4d4;
-    --chat-text-secondary: #ccc;
-    --chat-text-muted: #aaa;
-    --chat-text-placeholder: #888;
-    --chat-accent: #569cd6;
-    --chat-accent-hover: #6cb6ff;
-    --chat-overlay: rgba(0, 0, 0, 0.3);
-    --chat-shadow: rgba(0, 0, 0, 0.4);
-    --chat-code-bg: #2d2d2d;
-    --chat-code-text: #ce9178;
-    --chat-pre-bg: #1a1a1a;
-    --chat-pre-text: #d4d4d4;
-    --chat-prompt-ai: #c586c0;
-    --chat-tool-bg: #252526;
-    --chat-tool-border: #555;
-    --chat-tool-complete: #4ec9b0;
-    --chat-tool-name: #dcdcaa;
-    --chat-tool-result: #9cdcfe;
-    --chat-tool-error: #f48771;
-    --chat-tool-prefix: #555;
-    --chat-scrollbar-track: #1e1e1e;
-    --chat-scrollbar-thumb: #424242;
-    --chat-scrollbar-hover: #555;
-    --chat-heading: #e0e0e0;
-    --chat-strong: #e0e0e0;
-    --chat-em: #b5b5b5;
-    --chat-del: #888;
-    --chat-blockquote-bg: #252526;
-    --chat-blockquote-text: #aaa;
-    --chat-table-header-bg: #252526;
-    --chat-table-alt-bg: #1a1a1a;
-    --chat-input-bg: #1e1e1e;
-    --chat-btn-text: #1e1e1e;
-    --chat-ai-text: #9cdcfe;
-    --chat-user-text: #d4d4d4;
-    --chat-hover-bg: #333;
-    --chat-bg-secondary: #2a2a2a;
-    --chat-diff-add-bg: rgba(35, 134, 54, 0.15);
-    --chat-diff-add-text: #4ec9b0;
-    --chat-diff-del-bg: rgba(218, 54, 51, 0.15);
-    --chat-diff-del-text: #f48771;
+    --chat-bg: #2e3440;
+    --chat-header-bg: #3b4252;
+    --chat-border: #4c566a;
+    --chat-text: #d8dee9;
+    --chat-text-primary: #e5e9f0;
+    --chat-text-secondary: #c0c8d6;
+    --chat-text-muted: #a7b1c2;
+    --chat-text-placeholder: #a7b1c2;
+    --chat-accent: #88c0d0;
+    --chat-accent-hover: #8fbcbb;
+    --chat-overlay: rgba(46, 52, 64, 0.52);
+    --chat-shadow: rgba(46, 52, 64, 0.38);
+    --chat-code-bg: #3b4252;
+    --chat-code-text: #d08770;
+    --chat-pre-bg: #2b303b;
+    --chat-pre-text: #e5e9f0;
+    --chat-prompt-ai: #b48ead;
+    --chat-tool-bg: #3b4252;
+    --chat-tool-border: #4c566a;
+    --chat-tool-complete: #a3be8c;
+    --chat-tool-name: #ebcb8b;
+    --chat-tool-result: #88c0d0;
+    --chat-tool-error: #bf616a;
+    --chat-tool-prefix: #7b88a1;
+    --chat-scrollbar-track: #2e3440;
+    --chat-scrollbar-thumb: #4c566a;
+    --chat-scrollbar-hover: #5e81ac;
+    --chat-heading: #eceff4;
+    --chat-strong: #eceff4;
+    --chat-em: #c0c8d6;
+    --chat-del: #7b88a1;
+    --chat-blockquote-bg: #3b4252;
+    --chat-blockquote-text: #c0c8d6;
+    --chat-table-header-bg: #3b4252;
+    --chat-table-alt-bg: #343b4a;
+    --chat-input-bg: #2e3440;
+    --chat-btn-text: #ffffff;
+    --chat-ai-text: #88c0d0;
+    --chat-user-text: #e5e9f0;
+    --chat-hover-bg: #434c5e;
+    --chat-bg-secondary: #3b4252;
+    --chat-diff-add-bg: rgba(163, 190, 140, 0.16);
+    --chat-diff-add-text: #a3be8c;
+    --chat-diff-del-bg: rgba(191, 97, 106, 0.16);
+    --chat-diff-del-text: #bf616a;
   }
 
   /* 亮色主题变量 */
   :host(.chat-theme-light) {
-    --chat-bg: #ffffff;
-    --chat-header-bg: #f5f5f5;
-    --chat-border: #e0e0e0;
-    --chat-text: #333333;
-    --chat-text-primary: #333333;
-    --chat-text-secondary: #555555;
-    --chat-text-muted: #666;
-    --chat-text-placeholder: #aaaaaa;
-    --chat-accent: #0969da;
-    --chat-accent-hover: #0550ae;
-    --chat-overlay: rgba(0, 0, 0, 0.15);
-    --chat-shadow: rgba(0, 0, 0, 0.12);
-    --chat-code-bg: #eff1f3;
-    --chat-code-text: #d73e1d;
-    --chat-pre-bg: #f6f8fa;
-    --chat-pre-text: #333333;
-    --chat-prompt-ai: #8250df;
-    --chat-tool-bg: #f5f5f5;
-    --chat-tool-border: #d0d0d0;
-    --chat-tool-complete: #1a7f37;
-    --chat-tool-name: #953800;
-    --chat-tool-result: #0550ae;
-    --chat-tool-error: #cf222e;
-    --chat-tool-prefix: #bbb;
-    --chat-scrollbar-track: #ffffff;
-    --chat-scrollbar-thumb: #c8c8c8;
-    --chat-scrollbar-hover: #a0a0a0;
-    --chat-heading: #1f2328;
-    --chat-strong: #1f2328;
-    --chat-em: #555555;
-    --chat-del: #aaaaaa;
-    --chat-blockquote-bg: #f5f5f5;
-    --chat-blockquote-text: #666666;
-    --chat-table-header-bg: #f5f5f5;
-    --chat-table-alt-bg: #f6f8fa;
-    --chat-input-bg: #ffffff;
+    --chat-bg: #eceff4;
+    --chat-header-bg: #e5e9f0;
+    --chat-border: #c7d0dd;
+    --chat-text: #2e3440;
+    --chat-text-primary: #2e3440;
+    --chat-text-secondary: #434c5e;
+    --chat-text-muted: #4c566a;
+    --chat-text-placeholder: #5e6b82;
+    --chat-accent: #4c6f97;
+    --chat-accent-hover: #3f5f84;
+    --chat-overlay: rgba(46, 52, 64, 0.16);
+    --chat-shadow: rgba(46, 52, 64, 0.14);
+    --chat-code-bg: #e5e9f0;
+    --chat-code-text: #a34b5c;
+    --chat-pre-bg: #e5e9f0;
+    --chat-pre-text: #2e3440;
+    --chat-prompt-ai: #8a5d83;
+    --chat-tool-bg: #e5e9f0;
+    --chat-tool-border: #c7d0dd;
+    --chat-tool-complete: #5f7a60;
+    --chat-tool-name: #8f6f3e;
+    --chat-tool-result: #4c6f97;
+    --chat-tool-error: #a34b5c;
+    --chat-tool-prefix: #6b778c;
+    --chat-scrollbar-track: #eceff4;
+    --chat-scrollbar-thumb: #c7d0dd;
+    --chat-scrollbar-hover: #a7b1c2;
+    --chat-heading: #2e3440;
+    --chat-strong: #2e3440;
+    --chat-em: #434c5e;
+    --chat-del: #6b778c;
+    --chat-blockquote-bg: #e5e9f0;
+    --chat-blockquote-text: #434c5e;
+    --chat-table-header-bg: #e5e9f0;
+    --chat-table-alt-bg: #e7ebf1;
+    --chat-input-bg: #eceff4;
     --chat-btn-text: #ffffff;
-    --chat-ai-text: #0550ae;
-    --chat-user-text: #333333;
-    --chat-hover-bg: #e8e8e8;
-    --chat-bg-secondary: #f0f2f5;
-    --chat-diff-add-bg: rgba(35, 134, 54, 0.1);
-    --chat-diff-add-text: #1a7f37;
-    --chat-diff-del-bg: rgba(218, 54, 51, 0.1);
-    --chat-diff-del-text: #cf222e;
+    --chat-ai-text: #3f5f84;
+    --chat-user-text: #2e3440;
+    --chat-hover-bg: #dde3ec;
+    --chat-bg-secondary: #e5e9f0;
+    --chat-diff-add-bg: rgba(95, 122, 96, 0.14);
+    --chat-diff-add-text: #4f6b53;
+    --chat-diff-del-bg: rgba(163, 75, 92, 0.14);
+    --chat-diff-del-text: #8f3f4f;
   }
 
   /* 聊天框样式 */
@@ -3248,8 +3248,16 @@ export const chatStyles = css`
     flex-direction: column;
   }
 
+  .chat-terminal-container[data-terminal-provider="opencode"] {
+    padding: 0;
+  }
+
   .chat-terminal-container .xterm-rows {
     padding: 4px 0 0 4px;
+  }
+
+  .chat-terminal-container[data-terminal-provider="opencode"] .xterm-rows {
+    padding: 0;
   }
 
   .chat-terminal-container .xterm {

--- a/packages/core/src/client/ai.ts
+++ b/packages/core/src/client/ai.ts
@@ -2144,7 +2144,7 @@ export const chatStyles = css`
     font-weight: 500;
     color: var(--chat-text-secondary);
     font-family:
-      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   }
 
   .chat-modal-title-row {
@@ -2159,7 +2159,7 @@ export const chatStyles = css`
     background: var(--chat-border);
     padding: 1px 6px;
     border-radius: 3px;
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     white-space: nowrap;
     max-width: 160px;
     overflow: hidden;
@@ -2226,7 +2226,7 @@ export const chatStyles = css`
     border-radius: 4px;
     background: transparent;
     color: var(--chat-text-secondary);
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 11px;
     text-align: left;
     padding: 5px 8px;
@@ -2252,7 +2252,7 @@ export const chatStyles = css`
     background: var(--chat-border);
     padding: 1px 6px;
     border-radius: 3px;
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     white-space: nowrap;
     max-width: 160px;
     overflow: hidden;
@@ -2267,7 +2267,7 @@ export const chatStyles = css`
   .chat-context-info {
     font-size: 11px;
     color: var(--chat-text-muted);
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -2322,7 +2322,7 @@ export const chatStyles = css`
     border-radius: 4px;
     background: transparent;
     color: var(--chat-text-secondary);
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 11px;
     text-align: left;
     padding: 5px 8px;
@@ -2478,7 +2478,7 @@ export const chatStyles = css`
     flex-direction: column;
     gap: 0;
     min-height: 0;
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 13px;
     line-height: 1.5;
     background: var(--chat-bg);
@@ -2554,7 +2554,7 @@ export const chatStyles = css`
     font-size: 11px;
     line-height: 1.35;
     color: var(--chat-text-muted);
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   }
 
   .chat-message-context-tag {
@@ -2652,7 +2652,7 @@ export const chatStyles = css`
     background: var(--chat-code-bg);
     padding: 2px 6px;
     border-radius: 4px;
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 0.9em;
     color: var(--chat-code-text);
   }
@@ -2794,7 +2794,7 @@ export const chatStyles = css`
     padding: 4px 14px;
     background: var(--chat-header-bg);
     border-top: 1px solid var(--chat-border);
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 11px;
   }
 
@@ -2921,7 +2921,7 @@ export const chatStyles = css`
 
   .chat-input-prompt {
     color: var(--chat-accent);
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 13px;
     font-weight: 600;
     flex-shrink: 0;
@@ -2935,7 +2935,7 @@ export const chatStyles = css`
     border-radius: 4px;
     padding: 6px 10px;
     font-size: 13px;
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     color: var(--chat-text);
     resize: none;
     line-height: 1.4;
@@ -3088,7 +3088,7 @@ export const chatStyles = css`
   .diff-view {
     flex: 1;
     min-width: 0;
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 12px;
     line-height: 1.5;
     border-radius: 4px;
@@ -3163,7 +3163,7 @@ export const chatStyles = css`
     background: transparent;
     border: 1px solid var(--chat-border);
     color: var(--chat-text-muted);
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 11px;
     padding: 2px 8px;
     border-radius: 4px;
@@ -3196,7 +3196,7 @@ export const chatStyles = css`
   .read-result-block {
     flex: 1;
     min-width: 0;
-    font-family: 'SF Mono', 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+    font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 12px;
     line-height: 1.5;
     border-radius: 4px;

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -3710,7 +3710,7 @@ export class CodeInspectorComponent extends LitElement {
         position: fixed;
         pointer-events: none;
         z-index: 9999999999999;
-        font-family: 'PingFang SC';
+        font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         .margin-overlay {
           position: absolute;
           inset: 0;
@@ -3751,14 +3751,7 @@ export class CodeInspectorComponent extends LitElement {
         box-sizing: border-box;
         padding: 6px 8px;
         border-radius: 2px;
-        font-family:
-          'PingFang SC',
-          -apple-system,
-          BlinkMacSystemFont,
-          'Segoe UI',
-          'Helvetica Neue',
-          Arial,
-          sans-serif;
+        font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       }
       .element-info-top {
         top: -4px;
@@ -3859,9 +3852,7 @@ export class CodeInspectorComponent extends LitElement {
         z-index: 9999999999999999;
         min-width: 300px;
         max-width: min(max(30vw, 300px), 400px);
-        font-family:
-          ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-          'Liberation Mono', 'Courier New', monospace;
+        font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         display: flex;
         flex-direction: column;
         padding: 0;
@@ -3900,7 +3891,7 @@ export class CodeInspectorComponent extends LitElement {
           font-size: 9px;
           color: #777;
           margin-top: 1px;
-          font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+          font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         }
       }
 
@@ -4113,7 +4104,7 @@ if (!document.getElementById('code-inspector-notification-styles')) {
       padding: 12px 16px;
       border-radius: 8px;
       font-size: 14px;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-family: -apple-system, 'PingFang SC', BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       font-weight: 500;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
       opacity: 0;

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -2018,7 +2018,11 @@ export class CodeInspectorComponent extends LitElement {
     if (!containerEl) return;
 
     if (this.terminalManager && !this.terminalManager.isDisposed()) {
-      this.terminalManager.remount(containerEl, this.chatTheme);
+      this.terminalManager.remount(
+        containerEl,
+        this.chatTheme,
+        this.chatProvider || 'claudeCode',
+      );
       this.terminalManager.focus();
       return;
     }
@@ -2043,13 +2047,21 @@ export class CodeInspectorComponent extends LitElement {
 
     // 如果已有终端且未销毁，重新挂载到当前容器
     if (this.terminalManager && !this.terminalManager.isDisposed()) {
-      this.terminalManager.remount(containerEl, this.chatTheme);
+      this.terminalManager.remount(
+        containerEl,
+        this.chatTheme,
+        this.chatProvider || 'claudeCode',
+      );
       this.terminalManager.focus();
       return;
     }
 
     this.terminalManager = new AITerminalManager(this.ip, this.port);
-    this.terminalManager.mount(containerEl, this.chatTheme);
+    this.terminalManager.mount(
+      containerEl,
+      this.chatTheme,
+      this.chatProvider || 'claudeCode',
+    );
 
     this.terminalManager.onExit = (code: number) => {
       this.terminalExitCode = code;
@@ -2141,7 +2153,11 @@ export class CodeInspectorComponent extends LitElement {
       this.terminalManager.clear();
     } else {
       this.terminalManager = new AITerminalManager(this.ip, this.port);
-      this.terminalManager.mount(containerEl, this.chatTheme);
+      this.terminalManager.mount(
+        containerEl,
+        this.chatTheme,
+        this.chatProvider || 'claudeCode',
+      );
     }
 
     this.terminalManager.onExit = (code: number) => {

--- a/packages/core/src/server/ai-provider-common.ts
+++ b/packages/core/src/server/ai-provider-common.ts
@@ -250,6 +250,9 @@ export const __TEST_ONLY__ = {
   extractModelFromEvent,
   extractTextEvent,
   shouldIgnorePlainLine,
+  isRunnableCliPath,
+  pickCliPathFromSearchResult,
+  pickRunnableCliPath,
   findCodexCli,
   queryViaCli,
   getCodexSDKCtor,
@@ -603,6 +606,60 @@ export function handleCodexRequest(
 
 /** 缓存的 CLI 路径 */
 const cachedCliPathMap = new Map<string, string | null | undefined>();
+const WINDOWS_CLI_EXTENSIONS = ['.cmd', '.exe', '.bat', '.com'];
+
+function expandWindowsCliPathCandidates(filePath: string): string[] {
+  if (process.platform !== 'win32' || path.extname(filePath)) {
+    return [filePath];
+  }
+  return WINDOWS_CLI_EXTENSIONS.map((ext) => `${filePath}${ext}`);
+}
+
+function isRunnableCliPath(filePath: string): boolean {
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) return false;
+    if (process.platform === 'win32') {
+      return WINDOWS_CLI_EXTENSIONS.includes(
+        path.extname(filePath).toLowerCase(),
+      );
+    }
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pickRunnableCliPath(candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    const trimmed = candidate.trim();
+    if (!trimmed) continue;
+    for (const expanded of expandWindowsCliPathCandidates(trimmed)) {
+      if (isRunnableCliPath(expanded)) {
+        return expanded;
+      }
+    }
+  }
+  return null;
+}
+
+function pickCliPathFromSearchResult(candidates: string[]): string | null {
+  const trimmedCandidates = candidates
+    .map((candidate) => candidate.trim())
+    .filter(Boolean);
+  if (trimmedCandidates.length === 0) return null;
+  if (process.platform !== 'win32') return trimmedCandidates[0];
+
+  for (const ext of WINDOWS_CLI_EXTENSIONS) {
+    const match = trimmedCandidates.find(
+      (candidate) => path.extname(candidate).toLowerCase() === ext,
+    );
+    if (match) return match;
+  }
+
+  return trimmedCandidates[0];
+}
 
 /**
  * 查找本地 Codex CLI 路径
@@ -625,9 +682,11 @@ export function findCodexCli(
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
     if (result) {
-      const foundPath = result.split('\n')[0];
-      cachedCliPathMap.set(runtime.cliBinaryName, foundPath);
-      return foundPath;
+      const foundPath = pickCliPathFromSearchResult(result.split('\n'));
+      if (foundPath) {
+        cachedCliPathMap.set(runtime.cliBinaryName, foundPath);
+        return foundPath;
+      }
     }
   } catch {
     // 命令未找到
@@ -654,9 +713,10 @@ export function findCodexCli(
   ];
 
   for (const p of possiblePaths) {
-    if (fs.existsSync(p)) {
-      cachedCliPathMap.set(runtime.cliBinaryName, p);
-      return p;
+    const foundPath = pickRunnableCliPath([p]);
+    if (foundPath) {
+      cachedCliPathMap.set(runtime.cliBinaryName, foundPath);
+      return foundPath;
     }
   }
 

--- a/packages/core/src/server/ai-terminal.ts
+++ b/packages/core/src/server/ai-terminal.ts
@@ -127,12 +127,24 @@ const wsCache = { value: null as WsModule | null };
 
 const loadNodePty = () => loadOptionalModule('node-pty', nodePtyCache, normalizeNodePtyModule);
 const loadWs = () => loadOptionalModule('ws', wsCache, normalizeWsModule);
+const WINDOWS_SPAWN_EXTENSIONS = ['.cmd', '.exe', '.bat', '.com'];
+
+function expandWindowsSpawnCandidates(filePath: string): string[] {
+  if (process.platform !== 'win32' || path.extname(filePath)) {
+    return [filePath];
+  }
+  return WINDOWS_SPAWN_EXTENSIONS.map((ext) => `${filePath}${ext}`);
+}
 
 function isExecutableFile(filePath: string): boolean {
   try {
     const stat = fs.statSync(filePath);
     if (!stat.isFile()) return false;
-    if (process.platform === 'win32') return true;
+    if (process.platform === 'win32') {
+      return WINDOWS_SPAWN_EXTENSIONS.includes(
+        path.extname(filePath).toLowerCase(),
+      );
+    }
     fs.accessSync(filePath, fs.constants.X_OK);
     return true;
   } catch {
@@ -156,8 +168,10 @@ function resolveSpawnCommand(command: string): string | null {
   }
 
   for (const candidate of candidates) {
-    if (isExecutableFile(candidate)) {
-      return candidate;
+    for (const expanded of expandWindowsSpawnCandidates(candidate)) {
+      if (isExecutableFile(expanded)) {
+        return expanded;
+      }
     }
   }
 

--- a/packages/core/src/server/use-client.ts
+++ b/packages/core/src/server/use-client.ts
@@ -383,7 +383,7 @@ export async function getCodeWithWebComponent({
         injectCode,
         getProjectRecord(record)?.port || 0,
       );
-      if (!file.match(webComponentFilePath)) {
+      if (path.resolve(file) !== path.resolve(webComponentFilePath)) {
         const relativePath = normalizePath(
           path.relative(path.dirname(file), webComponentFilePath),
         );

--- a/packages/core/src/shared/utils.ts
+++ b/packages/core/src/shared/utils.ts
@@ -40,14 +40,7 @@ export function getFilePathWithoutExt(filePath: string) {
 }
 
 export function normalizePath(filepath: string) {
-  let normalizedPath = path.normalize(filepath);
-
-  // Convert Windows path separators to Mac path separators
-  if (process.platform === 'win32') {
-    normalizedPath = normalizedPath.replace(/\\/g, '/');
-  }
-
-  return normalizedPath;
+  return path.posix.normalize(filepath.replace(/\\/g, '/'));
 }
 
 export function isAstroToolbarFile(file: string) {

--- a/packages/core/types/client/ai-terminal.d.ts
+++ b/packages/core/types/client/ai-terminal.d.ts
@@ -10,26 +10,17 @@ export declare class AITerminalManager {
     private resizeObserver;
     private styleElement;
     private _disposed;
-    /** 进程退出回调 */
+    private currentTheme;
+    private currentProvider;
+    private outputHistory;
+    private outputHistoryLength;
     onExit?: (code: number) => void;
-    /** 错误回调 */
     onError?: (message: string) => void;
-    /** 运行时会话 ID 回调 */
     onRuntimeSession?: (runtimeSessionId: string, kind?: string) => void;
-    /** 运行时游标回调 */
     onRuntimeCursor?: (cursor: number) => void;
     constructor(ip: string, port: number);
-    /**
-     * 将终端挂载到 DOM 容器
-     */
-    mount(container: HTMLElement, theme: 'dark' | 'light'): void;
-    /**
-     * 当弹窗容器被卸载后，重新将终端挂载到新的 DOM 容器
-     */
-    remount(container: HTMLElement, theme: 'dark' | 'light'): void;
-    /**
-     * 连接 WebSocket 并创建终端会话
-     */
+    mount(container: HTMLElement, theme: 'dark' | 'light', provider?: ChatProvider): void;
+    remount(container: HTMLElement, theme: 'dark' | 'light', provider?: ChatProvider): void;
     connect(options: {
         provider: ChatProvider;
         prompt?: string;
@@ -39,53 +30,24 @@ export declare class AITerminalManager {
         cwd: string;
         model?: string;
     }): void;
-    /**
-     * 发送用户输入到 PTY
-     */
     sendInput(data: string): void;
-    /**
-     * 自适应终端尺寸
-     */
     fit(): void;
-    /**
-     * 切换终端主题
-     */
+    private proposeDimensions;
     setTheme(theme: 'dark' | 'light'): void;
-    /**
-     * 聚焦终端
-     */
     focus(): void;
-    /**
-     * 清空终端内容
-     */
     clear(): void;
-    /**
-     * 写入内容到终端（本地，不通过 WebSocket）
-     */
     write(data: string): void;
-    /**
-     * 关闭 WebSocket 连接（服务端会自动 kill PTY）
-     */
+    private renderOutput;
+    private getOverviewRulerWidth;
+    private applyProviderLayout;
+    private rememberOutput;
+    private clearOutputHistory;
+    private replayOutputHistory;
     closeWebSocket(): void;
-    /**
-     * 完全销毁：释放终端、WebSocket、ResizeObserver
-     */
     dispose(): void;
-    /**
-     * 是否已销毁
-     */
     isDisposed(): boolean;
     private attachTerminal;
-    /**
-     * 释放当前挂载的 xterm 实例，但保留 WebSocket 连接
-     */
     private detachTerminal;
-    /**
-     * 将 xterm CSS 注入到容器所在的 shadow root 或 document
-     */
     private injectCSS;
 }
-/**
- * 检查服务端终端功能是否可用
- */
 export declare function checkTerminalAvailable(ip: string, port: number): Promise<boolean>;

--- a/packages/core/types/server/ai-provider-common.d.ts
+++ b/packages/core/types/server/ai-provider-common.d.ts
@@ -117,6 +117,9 @@ export declare const __TEST_ONLY__: {
     extractModelFromEvent: typeof extractModelFromEvent;
     extractTextEvent: typeof extractTextEvent;
     shouldIgnorePlainLine: typeof shouldIgnorePlainLine;
+    isRunnableCliPath: typeof isRunnableCliPath;
+    pickCliPathFromSearchResult: typeof pickCliPathFromSearchResult;
+    pickRunnableCliPath: typeof pickRunnableCliPath;
     findCodexCli: typeof findCodexCli;
     queryViaCli: typeof queryViaCli;
     getCodexSDKCtor: typeof getCodexSDKCtor;
@@ -149,6 +152,9 @@ export declare function getModelInfo(codexOptions: CodexOptions | undefined): Pr
  * Codex provider 统一入口
  */
 export declare function handleCodexRequest(message: string, context: AIContext | null, history: AIMessage[], sessionId: string | undefined, cwd: string, codexOptions: CodexOptions | undefined, callbacks: ProviderCallbacks, runtime?: CodexProviderRuntime): ProviderResult;
+declare function isRunnableCliPath(filePath: string): boolean;
+declare function pickRunnableCliPath(candidates: string[]): string | null;
+declare function pickCliPathFromSearchResult(candidates: string[]): string | null;
 /**
  * 查找本地 Codex CLI 路径
  */

--- a/test/core/client/ai-terminal.test.ts
+++ b/test/core/client/ai-terminal.test.ts
@@ -1,0 +1,273 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+let AITerminalManagerCtor: typeof import('@/core/src/client/ai-terminal').AITerminalManager;
+
+beforeAll(async () => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+    cb(0);
+    return 1;
+  });
+
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  );
+
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: vi.fn(() => ({
+      fillStyle: '#000000',
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      getImageData: vi.fn(() => ({
+        data: new Uint8ClampedArray([0, 0, 0, 255]),
+      })),
+    })),
+  });
+
+  const terminalModule = await import('@/core/src/client/ai-terminal');
+  AITerminalManagerCtor = terminalModule.AITerminalManager;
+});
+
+function renderTerminalOutput(
+  data: string,
+  theme: 'dark' | 'light',
+  provider: 'claudeCode' | 'codex' | 'opencode' = 'codex',
+): string {
+  const manager = new AITerminalManagerCtor('127.0.0.1', 5173) as any;
+  const write = vi.fn();
+
+  manager.terminal = {
+    options: {},
+    reset: vi.fn(),
+    write,
+  };
+  manager.currentTheme = theme;
+  manager.currentProvider = provider;
+  manager.write(data);
+
+  const lastCall = write.mock.calls[write.mock.calls.length - 1];
+  return lastCall?.[0] || '';
+}
+
+describe('client ai terminal output colors', () => {
+  it('should remap dark truecolor backgrounds in light terminal output', () => {
+    const input = '\x1b[48;2;41;41;41mUse /skills\x1b[0m';
+    const output = renderTerminalOutput(input, 'light');
+
+    expect(output).toContain('\x1b[48;2;250;250;250m');
+    expect(output).not.toContain('48;2;41;41;41');
+    expect(renderTerminalOutput(input, 'dark')).toBe(input);
+  });
+
+  it('should remap dark ANSI background color indexes in light terminal output', () => {
+    expect(
+      renderTerminalOutput(
+        '\x1b[40mblack bg\x1b[0m',
+        'light',
+      ),
+    ).toContain('\x1b[48;2;250;250;250m');
+
+    expect(
+      renderTerminalOutput(
+        '\x1b[48;5;236mindexed bg\x1b[0m',
+        'light',
+      ),
+    ).toContain('\x1b[48;2;250;250;250m');
+  });
+
+  it('should remap low-contrast light foregrounds in light terminal output', () => {
+    expect(
+      renderTerminalOutput(
+        '\x1b[38;2;245;245;245mwhite text\x1b[0m',
+        'light',
+      ),
+    ).toContain('\x1b[38;2;56;58;66m');
+
+    expect(
+      renderTerminalOutput(
+        '\x1b[37mwhite ansi text\x1b[0m',
+        'light',
+      ),
+    ).toContain('\x1b[38;2;56;58;66m');
+  });
+
+  it('should preserve opencode terminal output without theme normalization', () => {
+    expect(
+      renderTerminalOutput('\x1b]12;#ffffff\x07prompt', 'light', 'opencode'),
+    ).toBe('\x1b]12;#ffffff\x07prompt');
+
+    expect(
+      renderTerminalOutput(
+        '\x1b[48;2;41;41;41mUse /skills\x1b[0m',
+        'light',
+        'opencode',
+      ),
+    ).toBe('\x1b[48;2;41;41;41mUse /skills\x1b[0m');
+  });
+
+  it('should remap low-contrast light backgrounds and dark foregrounds in dark terminal output', () => {
+    expect(
+      renderTerminalOutput(
+        '\x1b[48;2;250;250;250mlight bg\x1b[0m',
+        'dark',
+      ),
+    ).toContain('\x1b[48;2;40;44;52m');
+
+    expect(
+      renderTerminalOutput(
+        '\x1b[38;2;30;30;30mdark text\x1b[0m',
+        'dark',
+      ),
+    ).toContain('\x1b[38;2;171;178;191m');
+  });
+
+  it('should replay buffered output when the terminal theme changes', () => {
+    const manager = new AITerminalManagerCtor('127.0.0.1', 5173) as any;
+    const terminal = {
+      options: {},
+      reset: vi.fn(),
+      write: vi.fn(),
+    };
+    const input = '\x1b[48;2;41;41;41mUse /skills\x1b[0m';
+
+    manager.terminal = terminal;
+    manager.currentTheme = 'light';
+    manager.currentProvider = 'codex';
+    manager.write(input);
+
+    expect(terminal.write).toHaveBeenLastCalledWith(
+      expect.stringContaining('\x1b[48;2;250;250;250m'),
+    );
+
+    manager.setTheme('dark');
+
+    expect(terminal.reset).toHaveBeenCalledOnce();
+    expect(terminal.write).toHaveBeenLastCalledWith(input);
+  });
+
+  it('should replay raw buffered output for opencode theme changes', () => {
+    const manager = new AITerminalManagerCtor('127.0.0.1', 5173) as any;
+    const terminal = {
+      options: {},
+      reset: vi.fn(),
+      write: vi.fn(),
+    };
+    const input = '\x1b[48;2;41;41;41mUse /skills\x1b[0m';
+
+    manager.terminal = terminal;
+    manager.currentTheme = 'light';
+    manager.currentProvider = 'opencode';
+    manager.write(input);
+
+    expect(terminal.write).toHaveBeenLastCalledWith(input);
+
+    manager.setTheme('dark');
+
+    expect(terminal.reset).toHaveBeenCalledOnce();
+    expect(terminal.write).toHaveBeenLastCalledWith(input);
+  });
+
+  it('should remove scrollbar gutter for opencode layout', () => {
+    const manager = new AITerminalManagerCtor('127.0.0.1', 5173) as any;
+    const container = document.createElement('div');
+
+    manager.container = container;
+    manager.currentProvider = 'opencode';
+    manager.fitAddon = {};
+    manager.fit = vi.fn();
+    manager.terminal = { options: {} };
+
+    manager['applyProviderLayout']();
+
+    expect(container.dataset.terminalProvider).toBe('opencode');
+    expect(manager.terminal.options.overviewRuler).toEqual({ width: 0 });
+    expect(manager.fit).toHaveBeenCalledOnce();
+  });
+
+  it('should compute wider dimensions for opencode with zero gutter', () => {
+    const manager = new AITerminalManagerCtor('127.0.0.1', 5173) as any;
+    const host = document.createElement('div');
+    const terminalElement = document.createElement('div');
+
+    Object.defineProperty(host, 'parentElement', {
+      configurable: true,
+      value: null,
+    });
+    Object.defineProperty(terminalElement, 'parentElement', {
+      configurable: true,
+      value: host,
+    });
+
+    manager.container = document.createElement('div');
+    manager.terminal = {
+      element: terminalElement,
+      options: { scrollback: 5000 },
+      _core: {
+        _renderService: {
+          dimensions: {
+            css: {
+              cell: { width: 10, height: 20 },
+            },
+          },
+        },
+      },
+    };
+
+    const computedStyleSpy = vi
+      .spyOn(window, 'getComputedStyle')
+      .mockImplementation((el: Element) => {
+        if (el === host) {
+          return {
+            getPropertyValue: (prop: string) =>
+              prop === 'width' ? '470px' : prop === 'height' ? '200px' : '0px',
+          } as CSSStyleDeclaration;
+        }
+        return {
+          getPropertyValue: () => '0px',
+        } as CSSStyleDeclaration;
+      });
+
+    manager.currentProvider = 'codex';
+    expect(manager['proposeDimensions']()).toEqual({ cols: 46, rows: 10 });
+
+    manager.currentProvider = 'opencode';
+    expect(manager['proposeDimensions']()).toEqual({ cols: 47, rows: 10 });
+
+    computedStyleSpy.mockRestore();
+  });
+
+  it('should initialize opencode terminals with zero overview ruler width', () => {
+    const container = document.createElement('div');
+    const manager = new AITerminalManagerCtor('127.0.0.1', 5173);
+    document.body.appendChild(container);
+
+    manager.mount(container, 'dark', 'opencode');
+
+    expect((manager as any).currentProvider).toBe('opencode');
+    expect((manager as any).terminal.options.overviewRuler).toEqual({ width: 0 });
+    expect(container.dataset.terminalProvider).toBe('opencode');
+
+    manager.dispose();
+    container.remove();
+  });
+
+});
+

--- a/test/core/client/ai-terminal.test.ts
+++ b/test/core/client/ai-terminal.test.ts
@@ -72,7 +72,7 @@ describe('client ai terminal output colors', () => {
     const input = '\x1b[48;2;41;41;41mUse /skills\x1b[0m';
     const output = renderTerminalOutput(input, 'light');
 
-    expect(output).toContain('\x1b[48;2;250;250;250m');
+    expect(output).toContain('\x1b[48;2;236;239;244m');
     expect(output).not.toContain('48;2;41;41;41');
     expect(renderTerminalOutput(input, 'dark')).toBe(input);
   });
@@ -83,14 +83,14 @@ describe('client ai terminal output colors', () => {
         '\x1b[40mblack bg\x1b[0m',
         'light',
       ),
-    ).toContain('\x1b[48;2;250;250;250m');
+    ).toContain('\x1b[48;2;236;239;244m');
 
     expect(
       renderTerminalOutput(
         '\x1b[48;5;236mindexed bg\x1b[0m',
         'light',
       ),
-    ).toContain('\x1b[48;2;250;250;250m');
+    ).toContain('\x1b[48;2;236;239;244m');
   });
 
   it('should remap low-contrast light foregrounds in light terminal output', () => {
@@ -99,14 +99,14 @@ describe('client ai terminal output colors', () => {
         '\x1b[38;2;245;245;245mwhite text\x1b[0m',
         'light',
       ),
-    ).toContain('\x1b[38;2;56;58;66m');
+    ).toContain('\x1b[38;2;46;52;64m');
 
     expect(
       renderTerminalOutput(
         '\x1b[37mwhite ansi text\x1b[0m',
         'light',
       ),
-    ).toContain('\x1b[38;2;56;58;66m');
+    ).toContain('\x1b[38;2;46;52;64m');
   });
 
   it('should preserve opencode terminal output without theme normalization', () => {
@@ -126,17 +126,17 @@ describe('client ai terminal output colors', () => {
   it('should remap low-contrast light backgrounds and dark foregrounds in dark terminal output', () => {
     expect(
       renderTerminalOutput(
-        '\x1b[48;2;250;250;250mlight bg\x1b[0m',
+        '\x1b[48;2;236;239;244mlight bg\x1b[0m',
         'dark',
       ),
-    ).toContain('\x1b[48;2;40;44;52m');
+    ).toContain('\x1b[48;2;46;52;64m');
 
     expect(
       renderTerminalOutput(
         '\x1b[38;2;30;30;30mdark text\x1b[0m',
         'dark',
       ),
-    ).toContain('\x1b[38;2;171;178;191m');
+    ).toContain('\x1b[38;2;216;222;233m');
   });
 
   it('should replay buffered output when the terminal theme changes', () => {
@@ -154,7 +154,7 @@ describe('client ai terminal output colors', () => {
     manager.write(input);
 
     expect(terminal.write).toHaveBeenLastCalledWith(
-      expect.stringContaining('\x1b[48;2;250;250;250m'),
+      expect.stringContaining('\x1b[48;2;236;239;244m'),
     );
 
     manager.setTheme('dark');

--- a/test/core/server/ai-terminal.test.ts
+++ b/test/core/server/ai-terminal.test.ts
@@ -32,17 +32,53 @@ describe('ai terminal helpers', () => {
 
   it('should only resolve executable spawn commands when a path is provided', () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-terminal-cmd-'));
-    const executablePath = path.join(tempDir, 'runner.sh');
-    const nonExecutablePath = path.join(tempDir, 'plain.sh');
+    const executablePath = path.join(
+      tempDir,
+      process.platform === 'win32' ? 'runner.cmd' : 'runner.sh',
+    );
+    const nonExecutablePath = path.join(
+      tempDir,
+      process.platform === 'win32' ? 'plain.txt' : 'plain.sh',
+    );
 
-    fs.writeFileSync(executablePath, '#!/bin/sh\nexit 0\n');
+    fs.writeFileSync(
+      executablePath,
+      process.platform === 'win32'
+        ? '@echo off\r\nexit /b 0\r\n'
+        : '#!/bin/sh\nexit 0\n',
+    );
     fs.writeFileSync(nonExecutablePath, '#!/bin/sh\nexit 0\n');
-    fs.chmodSync(executablePath, 0o755);
-    fs.chmodSync(nonExecutablePath, 0o644);
+    if (process.platform !== 'win32') {
+      fs.chmodSync(executablePath, 0o755);
+      fs.chmodSync(nonExecutablePath, 0o644);
+    }
 
     expect(__TEST_ONLY__.resolveSpawnCommand(executablePath)).toBe(
       executablePath,
     );
     expect(__TEST_ONLY__.resolveSpawnCommand(nonExecutablePath)).toBeNull();
+  });
+
+  it('should resolve Windows extensionless npm shims to cmd siblings', () => {
+    const platformDesc = Object.getOwnPropertyDescriptor(process, 'platform');
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-terminal-win-'));
+    const shimPath = path.join(tempDir, 'codex');
+    const cmdPath = `${shimPath}.cmd`;
+
+    fs.writeFileSync(shimPath, '#!/bin/sh\n');
+    fs.writeFileSync(cmdPath, '@echo off\r\n');
+
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32',
+    });
+
+    try {
+      expect(__TEST_ONLY__.resolveSpawnCommand(shimPath)).toBe(cmdPath);
+    } finally {
+      if (platformDesc) {
+        Object.defineProperty(process, 'platform', platformDesc);
+      }
+    }
   });
 });

--- a/test/core/server/ai/claude-provider-helpers.test.ts
+++ b/test/core/server/ai/claude-provider-helpers.test.ts
@@ -535,7 +535,11 @@ describe('claude provider helpers', () => {
     process.env.HOME = fakeHome;
 
     const found = __TEST_ONLY__.findClaudeCodeCli();
-    expect(found).toBeNull();
+    if (process.platform === 'win32') {
+      expect(found).toBe(fallbackPath);
+    } else {
+      expect(found).toBeNull();
+    }
 
     process.env.PATH = oldPath;
     process.env.HOME = oldHome;

--- a/test/core/server/ai/codex-provider-helpers.test.ts
+++ b/test/core/server/ai/codex-provider-helpers.test.ts
@@ -792,9 +792,21 @@ describe('codex provider helpers', () => {
     const oldPath = process.env.PATH;
     const oldHome = process.env.HOME;
     const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
-    const fallbackPath = path.join(fakeHome, '.npm-global', 'bin', 'codex');
+    const fallbackBasePath = path.join(fakeHome, '.npm-global', 'bin', 'codex');
+    const fallbackPath =
+      process.platform === 'win32'
+        ? `${fallbackBasePath}.cmd`
+        : fallbackBasePath;
     fs.mkdirSync(path.dirname(fallbackPath), { recursive: true });
-    fs.writeFileSync(fallbackPath, '#!/bin/sh\necho codex');
+    fs.writeFileSync(
+      fallbackPath,
+      process.platform === 'win32'
+        ? '@echo off\r\necho codex\r\n'
+        : '#!/bin/sh\necho codex',
+    );
+    if (process.platform !== 'win32') {
+      fs.chmodSync(fallbackPath, 0o755);
+    }
     process.env.PATH = '';
     process.env.HOME = fakeHome;
     const discovered = __TEST_ONLY__.findCodexCli();
@@ -820,6 +832,32 @@ describe('codex provider helpers', () => {
     process.env.HOME = oldHome;
     if (platformDesc) {
       Object.defineProperty(process, 'platform', platformDesc);
+    }
+  });
+
+  it('should prefer Windows cmd shims over extensionless npm shims', () => {
+    const platformDesc = Object.getOwnPropertyDescriptor(process, 'platform');
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-win-shim-'));
+    const shimPath = path.join(tempDir, 'codex');
+    const cmdPath = `${shimPath}.cmd`;
+
+    fs.writeFileSync(shimPath, '#!/bin/sh\n');
+    fs.writeFileSync(cmdPath, '@echo off\r\n');
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32',
+    });
+
+    try {
+      expect(__TEST_ONLY__.isRunnableCliPath(shimPath)).toBe(false);
+      expect(__TEST_ONLY__.pickRunnableCliPath([shimPath])).toBe(cmdPath);
+      expect(
+        __TEST_ONLY__.pickCliPathFromSearchResult([shimPath, cmdPath]),
+      ).toBe(cmdPath);
+    } finally {
+      if (platformDesc) {
+        Object.defineProperty(process, 'platform', platformDesc);
+      }
     }
   });
 

--- a/test/core/server/server/create-server.test.ts
+++ b/test/core/server/server/create-server.test.ts
@@ -722,7 +722,7 @@ describe('server path helpers', () => {
 
   it('should expose a valid git root or empty string', () => {
     if (serverModule.ProjectRootPath) {
-      expect(serverModule.ProjectRootPath.startsWith('/')).toBe(true);
+      expect(path.isAbsolute(serverModule.ProjectRootPath)).toBe(true);
       return;
     }
 

--- a/test/core/server/transform/transform-astro.test.ts
+++ b/test/core/server/transform/transform-astro.test.ts
@@ -10,6 +10,10 @@ function getAstroPropagatedPathExpression() {
   return `typeof $$props !== 'undefined' && $$props && $$props[${pathName}] || Astro.props && Astro.props[${pathName}]`;
 }
 
+function astroPath(filePath: string, line: number, column: number, name: string) {
+  return JSON.stringify(`${filePath}:${line}:${column}:${name}`);
+}
+
 function createAstroFixture(content: string, compilerSource: string) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'code-inspector-astro-'));
   const srcDir = path.join(root, 'src');
@@ -56,7 +60,7 @@ describe('transformAstro compiler path', () => {
       );
 
       expect(result).toContain(
-        `${PathName}={${getAstroPropagatedPathExpression()} || "${filePath}:1:1:main"}`,
+        `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(filePath, 1, 1, 'main')}}`,
       );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
@@ -176,16 +180,16 @@ module.exports = {
       const result = await transformAstro(content, fixture.filePath, []);
 
       expect(result).toContain(
-        `${PathName}={${getAstroPropagatedPathExpression()} || "${fixture.filePath}:1:1:div"}`,
+        `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(fixture.filePath, 1, 1, 'div')}}`,
       );
       expect(result).toContain(
-        `${PathName}="${fixture.filePath}:1:${customOffset + 1}:custom-el"`,
+        `${PathName}=${astroPath(fixture.filePath, 1, customOffset + 1, 'custom-el')}`,
       );
       expect(result).toContain(
-        `${PathName}="${fixture.filePath}:1:${cardOffset + 1}:Card"`,
+        `${PathName}=${astroPath(fixture.filePath, 1, cardOffset + 1, 'Card')}`,
       );
       expect(result).toContain(
-        `${PathName}="${fixture.filePath}:1:${svgOffset + 1}:svg"`,
+        `${PathName}=${astroPath(fixture.filePath, 1, svgOffset + 1, 'svg')}`,
       );
       expect(result).toContain('<p data-insp-path="old">Text</p>');
       expect(result).not.toContain(':path"');
@@ -235,9 +239,9 @@ module.exports = {
     try {
       const result = await transformAstro(content, fixture.filePath, []);
 
-      expect(result).toContain(`${PathName}="${fixture.filePath}:1:1:div"`);
+      expect(result).toContain(`${PathName}=${astroPath(fixture.filePath, 1, 1, 'div')}`);
       expect(result).toContain(
-        `${PathName}="${fixture.filePath}:1:${svgOffset + 1}:svg"`,
+        `${PathName}=${astroPath(fixture.filePath, 1, svgOffset + 1, 'svg')}`,
       );
       expect(result).not.toContain(`${fixture.filePath}:1:${pathOffset + 1}:path`);
       expect(result).not.toContain(getAstroPropagatedPathExpression());
@@ -294,7 +298,7 @@ module.exports = {
       const result = await transformAstro(content, fixture.filePath, []);
 
       expect(result).toContain(
-        `${PathName}={${getAstroPropagatedPathExpression()} || "${fixture.filePath}:1:1:div"}`,
+        `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(fixture.filePath, 1, 1, 'div')}}`,
       );
     } finally {
       fixture.cleanup();
@@ -327,7 +331,7 @@ module.exports = {
       const result = await transformAstro(content, fixture.filePath, []);
 
       expect(result).toContain(
-        `${PathName}={${getAstroPropagatedPathExpression()} || "${fixture.filePath}:1:1:div"}`,
+        `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(fixture.filePath, 1, 1, 'div')}}`,
       );
     } finally {
       fixture.cleanup();
@@ -356,7 +360,7 @@ module.exports = {
       const result = await transformAstro(content, fixture.filePath, []);
 
       expect(result).toContain(
-        `<section class="inspector-complex" ${PathName}={${getAstroPropagatedPathExpression()} || "${fixture.filePath}:4:1:section"}`,
+        `<section class="inspector-complex" ${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(fixture.filePath, 4, 1, 'section')}}`,
       );
     } finally {
       fixture.cleanup();
@@ -380,7 +384,7 @@ module.exports = {
       const result = await transformAstro(content, fixture.filePath, []);
 
       expect(result).toContain(
-        `${PathName}={${getAstroPropagatedPathExpression()} || "${fixture.filePath}:1:1:section"}`,
+        `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(fixture.filePath, 1, 1, 'section')}}`,
       );
     } finally {
       fixture.cleanup();

--- a/test/core/server/transform/transform-mdx.test.ts
+++ b/test/core/server/transform/transform-mdx.test.ts
@@ -34,6 +34,10 @@ function transformWholeMdx(
   return transformMdx(content, filePath, escapeTags, filePath);
 }
 
+function mdxPath(filePath: string, line: number, column: number, name: string) {
+  return JSON.stringify(`${filePath}:${line}:${column}:${name}`);
+}
+
 describe('transformMdx parser path', () => {
   it('should fall back to scanner when parser package cannot be resolved', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'code-inspector-mdx-missing-'));
@@ -50,7 +54,7 @@ describe('transformMdx parser path', () => {
       );
 
       expect(result).toContain(
-        `${PathName}="${filePath}:1:1:section"`,
+        `${PathName}=${mdxPath(filePath, 1, 1, 'section')}`,
       );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
@@ -78,7 +82,7 @@ describe('transformMdx parser path', () => {
       );
 
       expect(result).toContain(
-        `${PathName}="${filePath}:1:1:article"`,
+        `${PathName}=${mdxPath(filePath, 1, 1, 'article')}`,
       );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
@@ -115,7 +119,7 @@ module.exports = {
       const result = await transformMdx(content, fixture.filePath, []);
 
       expect(result).toContain(
-        `${PathName}={props && props[${JSON.stringify(PathName)}] || "${fixture.filePath}:1:1:article"}`,
+        `${PathName}={props && props[${JSON.stringify(PathName)}] || ${mdxPath(fixture.filePath, 1, 1, 'article')}}`,
       );
     } finally {
       fixture.cleanup();
@@ -132,7 +136,7 @@ module.exports = {
     try {
       const result = await transformWholeMdx(content, fixture.filePath);
 
-      expect(result).toContain(`${PathName}="${fixture.filePath}:1:1:main"`);
+      expect(result).toContain(`${PathName}=${mdxPath(fixture.filePath, 1, 1, 'main')}`);
     } finally {
       fixture.cleanup();
     }
@@ -155,10 +159,10 @@ module.exports = {
     try {
       const result = await transformMdx(content, fixture.filePath, []);
 
-      expect(result).toContain(`${PathName}="${fixture.filePath}:1:1:h1"`);
-      expect(result).toContain(`${PathName}="${fixture.filePath}:3:1:ul"`);
-      expect(result).toContain(`${PathName}="${fixture.filePath}:3:1:li"`);
-      expect(result).toContain(`${PathName}="${fixture.filePath}:6:1:section"`);
+      expect(result).toContain(`${PathName}=${mdxPath(fixture.filePath, 1, 1, 'h1')}`);
+      expect(result).toContain(`${PathName}=${mdxPath(fixture.filePath, 3, 1, 'ul')}`);
+      expect(result).toContain(`${PathName}=${mdxPath(fixture.filePath, 3, 1, 'li')}`);
+      expect(result).toContain(`${PathName}=${mdxPath(fixture.filePath, 6, 1, 'section')}`);
     } finally {
       fixture.cleanup();
     }
@@ -237,13 +241,13 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `${PathName}="${fixture.filePath}:5:1:Card"`,
+        `${PathName}=${mdxPath(fixture.filePath, 5, 1, 'Card')}`,
       );
       expect(result).toContain(
-        `${PathName}="${fixture.filePath}:6:1:svg"`,
+        `${PathName}=${mdxPath(fixture.filePath, 6, 1, 'svg')}`,
       );
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:3:1:h1">Title</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 3, 1, 'h1')}>Title</h1>`,
       );
       expect(result).not.toContain('Props<Card data-insp-path');
       expect(result).not.toContain(`:path"`);
@@ -282,7 +286,7 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `${PathName}={props && props[${JSON.stringify(PathName)}] || "${fixture.filePath}:1:1:div"}`,
+        `${PathName}={props && props[${JSON.stringify(PathName)}] || ${mdxPath(fixture.filePath, 1, 1, 'div')}}`,
       );
     } finally {
       fixture.cleanup();
@@ -308,10 +312,10 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `${PathName}="${fixture.filePath}:1:1:Card"`,
+        `${PathName}=${mdxPath(fixture.filePath, 1, 1, 'Card')}`,
       );
       expect(result).toContain(
-        `${PathName}="${fixture.filePath}:1:9:div"`,
+        `${PathName}=${mdxPath(fixture.filePath, 1, 9, 'div')}`,
       );
     } finally {
       fixture.cleanup();
@@ -368,7 +372,7 @@ module.exports = {
       expect(result).toContain('<section data-insp-path="manual">Manual</section>');
       expect(result).toContain('<aside>Invalid position</aside>');
       expect(result).toContain(
-        `${PathName}="${fixture.filePath}:3:1:nav"`,
+        `${PathName}=${mdxPath(fixture.filePath, 3, 1, 'nav')}`,
       );
       expect(result).not.toContain(':section"');
       expect(result).not.toContain(':aside"');
@@ -418,16 +422,16 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `<ul ${PathName}="${fixture.filePath}:1:1:ul">`,
+        `<ul ${PathName}=${mdxPath(fixture.filePath, 1, 1, 'ul')}>`,
       );
       expect(result).toContain(
-        `<li ${PathName}="${fixture.filePath}:1:1:li">Bullet</li>`,
+        `<li ${PathName}=${mdxPath(fixture.filePath, 1, 1, 'li')}>Bullet</li>`,
       );
       expect(result).toContain(
-        `<ol ${PathName}="${fixture.filePath}:2:1:ol">`,
+        `<ol ${PathName}=${mdxPath(fixture.filePath, 2, 1, 'ol')}>`,
       );
       expect(result).toContain(
-        `<li ${PathName}="${fixture.filePath}:2:1:li">Ordered</li>`,
+        `<li ${PathName}=${mdxPath(fixture.filePath, 2, 1, 'li')}>Ordered</li>`,
       );
     } finally {
       fixture.cleanup();
@@ -451,13 +455,13 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:1:1:h1">1 &lt; 2 and 3 &gt; 2 and <span>ok</span></h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 1, 1, 'h1')}>1 &lt; 2 and 3 &gt; 2 and <span>ok</span></h1>`,
       );
       expect(result).toContain(
-        `<li ${PathName}="${fixture.filePath}:3:1:li">a &lt; b &gt; c</li>`,
+        `<li ${PathName}=${mdxPath(fixture.filePath, 3, 1, 'li')}>a &lt; b &gt; c</li>`,
       );
       expect(result).toContain(
-        `<p ${PathName}="${fixture.filePath}:5:3:p">c &lt; d &gt; e</p>`,
+        `<p ${PathName}=${mdxPath(fixture.filePath, 5, 3, 'p')}>c &lt; d &gt; e</p>`,
       );
       expect(result).not.toContain(`${fixture.filePath}:1:13:span`);
     } finally {
@@ -484,16 +488,16 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:1:1:h1">C# and &copy;</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 1, 1, 'h1')}>C# and &copy;</h1>`,
       );
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:3:1:h1">Escaped &#123;literal&#125; and {value}</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 3, 1, 'h1')}>Escaped &#123;literal&#125; and {value}</h1>`,
       );
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:5:1:h1">Keep closing marker</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 5, 1, 'h1')}>Keep closing marker</h1>`,
       );
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:7:1:h1"><strong>bold #</strong> and - marker</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 7, 1, 'h1')}><strong>bold #</strong> and - marker</h1>`,
       );
     } finally {
       fixture.cleanup();
@@ -514,13 +518,13 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `<ul ${PathName}="${fixture.filePath}:1:1:ul">`,
+        `<ul ${PathName}=${mdxPath(fixture.filePath, 1, 1, 'ul')}>`,
       );
       expect(result).toContain(
-        `<li ${PathName}="${fixture.filePath}:1:1:li">[x] Completed task from remark-gfm syntax</li>`,
+        `<li ${PathName}=${mdxPath(fixture.filePath, 1, 1, 'li')}>[x] Completed task from remark-gfm syntax</li>`,
       );
       expect(result).toContain(
-        `<li ${PathName}="${fixture.filePath}:2:1:li">[ ] Pending task from remark-gfm syntax</li>`,
+        `<li ${PathName}=${mdxPath(fixture.filePath, 2, 1, 'li')}>[ ] Pending task from remark-gfm syntax</li>`,
       );
       expect(result).not.toContain('type="checkbox"');
       expect(result).not.toContain('<input');
@@ -542,7 +546,7 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:1:1:h1"><a href="https://example.com/docs/(section)" title="Nested title">Nested [label] link</a> and <img src="https://example.com/assets/(demo).png" alt="Decorated alt text" title="Asset title" /></h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 1, 1, 'h1')}><a href="https://example.com/docs/(section)" title="Nested title">Nested [label] link</a> and <img src="https://example.com/assets/(demo).png" alt="Decorated alt text" title="Asset title" /></h1>`,
       );
     } finally {
       fixture.cleanup();
@@ -566,13 +570,13 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:1:1:h1">Result {format({ label: 'brace } text', meta: { count: visibleGroups.length }, template: \`value \${visibleGroups[0]?.id}\` })}</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 1, 1, 'h1')}>Result {format({ label: 'brace } text', meta: { count: visibleGroups.length }, template: \`value \${visibleGroups[0]?.id}\` })}</h1>`,
       );
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:3:1:h1">Regex {(/value\\}/).test('value}') ? 'regex literal matched' : 'regex literal missed'}</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 3, 1, 'h1')}>Regex {(/value\\}/).test('value}') ? 'regex literal matched' : 'regex literal missed'}</h1>`,
       );
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:5:1:h1">Comment {value /* comment } */ ?? 'fallback'}</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 5, 1, 'h1')}>Comment {value /* comment } */ ?? 'fallback'}</h1>`,
       );
     } finally {
       fixture.cleanup();
@@ -596,13 +600,13 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:1:1:h1">Regex {/[\\]}]/.test(value)}</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 1, 1, 'h1')}>Regex {/[\\]}]/.test(value)}</h1>`,
       );
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:3:1:h1">Leading regex { /abc/.test(value) }</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 3, 1, 'h1')}>Leading regex { /abc/.test(value) }</h1>`,
       );
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:5:1:h1">Return regex {(() => { return /abc/.test(value) })()}</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 5, 1, 'h1')}>Return regex {(() => { return /abc/.test(value) })()}</h1>`,
       );
     } finally {
       fixture.cleanup();
@@ -681,13 +685,13 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:1:1:h1"><strong>strong &lt; text &gt;</strong> <em>em &#123; text &#125;</em> <del>del &lt; text</del> <a href="https://example.com"><code>code &lt; &gt; &#123; &#125;</code></a></h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 1, 1, 'h1')}><strong>strong &lt; text &gt;</strong> <em>em &#123; text &#125;</em> <del>del &lt; text</del> <a href="https://example.com"><code>code &lt; &gt; &#123; &#125;</code></a></h1>`,
       );
       expect(result).toContain(
-        `<li ${PathName}="${fixture.filePath}:3:1:li"><strong># label &lt; 2</strong> and - literal</li>`,
+        `<li ${PathName}=${mdxPath(fixture.filePath, 3, 1, 'li')}><strong># label &lt; 2</strong> and - literal</li>`,
       );
       expect(result).toContain(
-        `<p ${PathName}="${fixture.filePath}:5:3:p"><a href="https://example.com">label &lt; value &gt;</a> and <code>code &lt;tag&gt; &#123;x&#125;</code></p>`,
+        `<p ${PathName}=${mdxPath(fixture.filePath, 5, 3, 'p')}><a href="https://example.com">label &lt; value &gt;</a> and <code>code &lt;tag&gt; &#123;x&#125;</code></p>`,
       );
     } finally {
       fixture.cleanup();
@@ -751,9 +755,9 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:2:1:h1"><span>Nested</span></h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 2, 1, 'h1')}><span>Nested</span></h1>`,
       );
-      expect(result).toContain(`${PathName}="${fixture.filePath}:3:1:div"`);
+      expect(result).toContain(`${PathName}=${mdxPath(fixture.filePath, 3, 1, 'div')}`);
       expect(result).not.toContain(`${fixture.filePath}:2:3:span`);
     } finally {
       fixture.cleanup();
@@ -777,7 +781,7 @@ module.exports = {
       const result = await transformMdx(content, fixture.filePath, []);
 
       expect(result).not.toContain(`${fixture.filePath}:2:18:span`);
-      expect(result).toContain(`${PathName}="${fixture.filePath}:5:1:section"`);
+      expect(result).toContain(`${PathName}=${mdxPath(fixture.filePath, 5, 1, 'section')}`);
     } finally {
       fixture.cleanup();
     }
@@ -795,7 +799,7 @@ module.exports = {
 
       expect(result).toContain('title: Demo');
       expect(result).toContain(
-        `<h1 ${PathName}="${fixture.filePath}:4:1:h1">Title</h1>`,
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 4, 1, 'h1')}>Title</h1>`,
       );
     } finally {
       fixture.cleanup();

--- a/test/core/shared/record-cache/find-port.test.ts
+++ b/test/core/shared/record-cache/find-port.test.ts
@@ -76,10 +76,10 @@ describe('findPort', () => {
   });
 
   describe('when port exists in memory cache', () => {
-    it('should return port from memory cache', async function() {
+    it('should return port from memory cache', async () => {
       // Skip on Windows as chmod doesn't work the same way
       if (process.platform === 'win32') {
-        this.skip();
+        return;
       }
 
       vi.spyOn(process, 'cwd').mockReturnValue('/memory/cache/project');
@@ -186,10 +186,10 @@ describe('findPort', () => {
   });
 
   describe('when port is in RecordCache but file has no port', () => {
-    it('should return port from RecordCache when file is writable but has no port entry', async function() {
+    it('should return port from RecordCache when file is writable but has no port entry', async () => {
       // Skip on Windows as chmod doesn't work the same way
       if (process.platform === 'win32') {
-        this.skip();
+        return;
       }
 
       vi.spyOn(process, 'cwd').mockReturnValue('/recordcache/fallback/project');
@@ -256,10 +256,10 @@ describe('findPort', () => {
       expect(port).toBe(4444);
     });
 
-    it('should return port from memory cache when file is not writable', async function() {
+    it('should return port from memory cache when file is not writable', async () => {
       // Skip on Windows as chmod doesn't work the same way
       if (process.platform === 'win32') {
-        this.skip();
+        return;
       }
 
       vi.spyOn(process, 'cwd').mockReturnValue('/cache/fallback/project');

--- a/test/core/shared/record-cache/get-project-record.test.ts
+++ b/test/core/shared/record-cache/get-project-record.test.ts
@@ -119,10 +119,10 @@ describe('getProjectRecord', () => {
   });
 
   describe('when no write permission', () => {
-    it('should return record from memory cache', function() {
+    it('should return record from memory cache', () => {
       // Skip on Windows as chmod doesn't work the same way
       if (process.platform === 'win32') {
-        this.skip();
+        return;
       }
 
       vi.spyOn(process, 'cwd').mockReturnValue('/no/permission/project');
@@ -156,10 +156,10 @@ describe('getProjectRecord', () => {
       });
     });
 
-    it('should return undefined from memory cache when no record exists', function() {
+    it('should return undefined from memory cache when no record exists', () => {
       // Skip on Windows as chmod doesn't work the same way
       if (process.platform === 'win32') {
-        this.skip();
+        return;
       }
 
       vi.spyOn(process, 'cwd').mockReturnValue('/fresh/no/permission/project');

--- a/test/core/shared/record-cache/reset-file-record.test.ts
+++ b/test/core/shared/record-cache/reset-file-record.test.ts
@@ -150,10 +150,10 @@ describe('resetFileRecord', () => {
   });
 
   describe('when no write permission', () => {
-    it('should store record in memory cache', function() {
+    it('should store record in memory cache', () => {
       // Skip on Windows as chmod doesn't work the same way
       if (process.platform === 'win32') {
-        this.skip();
+        return;
       }
 
       vi.spyOn(process, 'cwd').mockReturnValue('/no/permission/project');

--- a/test/core/shared/record-cache/set-project-record.test.ts
+++ b/test/core/shared/record-cache/set-project-record.test.ts
@@ -182,10 +182,10 @@ describe('setProjectRecord', () => {
   });
 
   describe('when no write permission', () => {
-    it('should store record in memory cache', function() {
+    it('should store record in memory cache', () => {
       // Skip on Windows as chmod doesn't work the same way
       if (process.platform === 'win32') {
-        this.skip();
+        return;
       }
 
       vi.spyOn(process, 'cwd').mockReturnValue('/no/write/permission/project');

--- a/test/core/shared/utils/has-write-permission.test.ts
+++ b/test/core/shared/utils/has-write-permission.test.ts
@@ -50,10 +50,10 @@ describe('hasWritePermission', () => {
       expect(hasWritePermission(testFile)).toBe(true);
     });
 
-    it('should return false for read-only file', function() {
+    it('should return false for read-only file', () => {
       // Skip on Windows as chmod doesn't work the same way
       if (process.platform === 'win32') {
-        this.skip();
+        return;
       }
       expect(hasWritePermission(readOnlyFile)).toBe(false);
     });
@@ -74,10 +74,10 @@ describe('hasWritePermission', () => {
       expect(hasWritePermission(nonExistentPath)).toBe(false);
     });
 
-    it('should return false if parent directory is not writable', function() {
+    it('should return false if parent directory is not writable', () => {
       // Skip on Windows as chmod doesn't work the same way
       if (process.platform === 'win32') {
-        this.skip();
+        return;
       }
 
       // Create a read-only directory


### PR DESCRIPTION
## Summary
- improve AI terminal provider compatibility across client and server flows
- refine terminal theme handling, replay behavior, and provider-specific layout behavior
- add and update related terminal/provider tests

## Testing
- `vitest run test/core/server/ai-terminal.test.ts test/core/server/ai/codex-provider-helpers.test.ts`
- `vitest run test/core/client/ai-terminal.test.ts` currently fails in 5 assertions because the expected color values still reflect the previous terminal theme palette while the branch now uses the updated palette
