### PR TITLE
test: improve e2e retry and timeout

### DIFF
--- a/e2e/demos.config.ts
+++ b/e2e/demos.config.ts
@@ -7,6 +7,7 @@ export const demosRoot = path.join(repoRoot, 'demos');
 export const INSPECTOR_PORT = 5678;
 // 注入属性名（packages/core/src/shared/constant.ts -> PathName）
 export const PATH_NAME = 'data-insp-path';
+export const DEFAULT_READY_TIMEOUT_MS = 240_000;
 
 // 通用 dev-server URL 解析：匹配 stdout 中第一个 http(s)://<本机host>:<port>
 // 覆盖 localhost / 127.0.0.1 / 0.0.0.0 / [::1] / [::]（部分工具只打印后几种）
@@ -22,7 +23,7 @@ export interface DemoConfig {
   args?: string[];
   /** 额外环境变量 */
   env?: Record<string, string>;
-  /** 等待 dev server 就绪的超时（ms），默认 60000 */
+  /** 等待 dev server 就绪的超时（ms），默认 240000 */
   readyTimeoutMs?: number;
   /** 自定义 URL 解析正则（默认 GENERIC_URL_REGEX） */
   urlRegex?: RegExp;
@@ -32,7 +33,7 @@ export interface DemoConfig {
   inspectorPort?: number;
 }
 
-const HEAVY = 120_000;
+const HEAVY = DEFAULT_READY_TIMEOUT_MS;
 
 export const demos: DemoConfig[] = [
   // ---- vite 系（默认 `vite`，通用解析）----

--- a/e2e/helpers/boot-demo.ts
+++ b/e2e/helpers/boot-demo.ts
@@ -1,7 +1,12 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import path from 'node:path';
 import treeKill from 'tree-kill';
-import { demosRoot, GENERIC_URL_REGEX, type DemoConfig } from '../demos.config';
+import {
+  DEFAULT_READY_TIMEOUT_MS,
+  demosRoot,
+  GENERIC_URL_REGEX,
+  type DemoConfig,
+} from '../demos.config';
 
 const ANSI = /\x1b\[[0-9;]*m/g;
 
@@ -45,7 +50,7 @@ export async function bootDemo(cfg: DemoConfig): Promise<BootedDemo> {
   const cwd = path.join(demosRoot, cfg.dir);
   const cmd = cfg.cmd ?? 'pnpm';
   const args = cfg.args ?? ['run', 'dev'];
-  const timeout = cfg.readyTimeoutMs ?? 60_000;
+  const timeout = cfg.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
   const urlRegex = cfg.urlRegex ?? GENERIC_URL_REGEX;
 
   const proc = spawn(cmd, args, {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,8 +6,8 @@ export default defineConfig({
   testDir: './tests',
   fullyParallel: false,
   workers: 1,
-  retries: 0,
-  // 单用例含 dev server 冷启动（最慢的 next/nuxt/vue-cli 可达 ~2min）+ 页面加载 + 断言
+  retries: process.env.CI ? 3 : 0,
+  // 单用例含 dev server 冷启动 + 页面加载 + 断言
   timeout: 240_000,
   expect: { timeout: 15_000 },
   reporter: [['list']],

--- a/e2e/tests/l1-smoke.spec.ts
+++ b/e2e/tests/l1-smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { demos } from '../demos.config';
+import { DEFAULT_READY_TIMEOUT_MS, demos } from '../demos.config';
 import { bootDemo, type BootedDemo } from '../helpers/boot-demo';
 import {
   collectInspPaths,
@@ -10,7 +10,7 @@ import {
 // L1：对每个 demo 验证 ① dev server 成功启动并渲染 ② data-insp-path 正确注入。
 for (const demo of demos) {
   test(`L1 smoke: ${demo.dir}`, async ({ page }) => {
-    test.setTimeout((demo.readyTimeoutMs ?? 60_000) + 60_000);
+    test.setTimeout((demo.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS) + 60_000);
 
     let booted: BootedDemo | undefined;
     try {

--- a/e2e/tests/l2-locate.spec.ts
+++ b/e2e/tests/l2-locate.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { demos, PATH_NAME } from '../demos.config';
+import { DEFAULT_READY_TIMEOUT_MS, demos, PATH_NAME } from '../demos.config';
 import { bootDemo, type BootedDemo } from '../helpers/boot-demo';
 import { parseInspPath } from '../helpers/inspector';
 import { MockInspectorServer } from '../helpers/mock-server';
@@ -15,7 +15,7 @@ demos.forEach((demo, index) => {
 
 for (const demo of demos) {
   test(`L2 locate: ${demo.dir}`, async ({ page }) => {
-    test.setTimeout((demo.readyTimeoutMs ?? 60_000) + 60_000);
+    test.setTimeout((demo.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS) + 60_000);
 
     let booted: BootedDemo | undefined;
     let mockServer: MockInspectorServer | undefined;


### PR DESCRIPTION
## Summary
- enable Playwright retries in CI for e2e cases
- raise the default demo ready timeout to 240s
- align per-test timeout calculations with the shared default

## Test
- pnpm exec playwright test -c e2e/playwright.config.ts l1-smoke --list
- pnpm exec playwright test -c e2e/playwright.config.ts l2-locate --list