### PR TITLE
fix: inject vue inspector attributes via compiler transform + code optimizations

### DIFF
--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,3 +1,6 @@
-export { transformCode } from './transform';
+export {
+  createVueInspectorNodeTransform,
+  transformCode,
+} from './transform';
 export * from './use-client';
 export * from './server';

--- a/packages/core/src/server/transform/index.ts
+++ b/packages/core/src/server/transform/index.ts
@@ -4,6 +4,7 @@ import { transformJsx } from './transform-jsx';
 import { transformMdx } from './transform-mdx';
 import { transformSvelte } from './transform-svelte';
 import { transformVue } from './transform-vue';
+export { createVueInspectorNodeTransform } from './vue-node-transform';
 import { EscapeTags, PathType, isIgnoredFile } from '../../shared';
 import { getRelativeOrAbsolutePath } from '../server';
 

--- a/packages/core/src/server/transform/index.ts
+++ b/packages/core/src/server/transform/index.ts
@@ -5,7 +5,7 @@ import { transformMdx } from './transform-mdx';
 import { transformSvelte } from './transform-svelte';
 import { transformVue } from './transform-vue';
 export { createVueInspectorNodeTransform } from './vue-node-transform';
-import { EscapeTags, PathType, isIgnoredFile } from '../../shared';
+import { EscapeTags, PathType, isIgnoredFile, CodeInspectorEscapeTags } from '../../shared';
 import { getRelativeOrAbsolutePath } from '../server';
 
 type FileType = 'vue' | 'jsx' | 'svelte' | 'astro' | 'mdx' | unknown;
@@ -18,22 +18,6 @@ type TransformCodeParams = {
   pathType: PathType;
   mdx?: boolean;
 };
-
-const CodeInspectorEscapeTags = [
-  'style',
-  'script',
-  'template',
-  'transition',
-  'keepalive',
-  'keep-alive',
-  'component',
-  'slot',
-  'teleport',
-  'transition-group',
-  'transitiongroup',
-  'suspense',
-  'fragment',
-];
 
 export async function transformCode(params: TransformCodeParams) {
   let {

--- a/packages/core/src/server/transform/transform-vue-pug.ts
+++ b/packages/core/src/server/transform/transform-vue-pug.ts
@@ -1,6 +1,7 @@
 import MagicString from 'magic-string';
 import { EscapeTags, PathName, isEscapeTags } from '../../shared';
 import type { ElementNode } from '@vue/compiler-dom';
+import { NodeTypes } from '@vue/compiler-dom';
 import * as pug from 'volar-service-pug/lib/languageService';
 
 interface AstLocation {
@@ -13,7 +14,6 @@ export interface PugFileInfo {
   offsets: number[];
 }
 
-const AttributeNodeType = 6;
 export const pugMap = new Map<string, PugFileInfo>(); // 使用了 pug 模板的 vue 文件集合
 
 export function belongTemplate(
@@ -122,7 +122,7 @@ export function isPugTemplate(templateNode: ElementNode | undefined): boolean {
   }
   return (templateNode.props || []).some(
     (prop) =>
-      prop.type === AttributeNodeType &&
+      prop.type === NodeTypes.ATTRIBUTE &&
       prop.name === 'lang' &&
       prop.value?.content === 'pug',
   );

--- a/packages/core/src/server/transform/transform-vue.ts
+++ b/packages/core/src/server/transform/transform-vue.ts
@@ -5,6 +5,7 @@ import type {
   NodeTransform,
   ElementNode,
 } from '@vue/compiler-dom';
+import { NodeTypes } from '@vue/compiler-dom';
 import { ProjectRootPath } from '../server';
 import path from 'path';
 import fs from 'fs';
@@ -15,7 +16,6 @@ import {
   calculateLineOffsets,
 } from './transform-vue-pug';
 
-const VueElementType = 1;
 type VueCompilerDom = Pick<
   typeof import('@vue/compiler-dom'),
   'parse' | 'transform'
@@ -79,7 +79,7 @@ export async function transformVue(
 
   // 判断是否为 Pug 模版
   const templateNode = ast.children.find(
-    (node) => node.type === VueElementType && node.tag === 'template',
+    (node) => node.type === NodeTypes.ELEMENT && node.tag === 'template',
   ) as ElementNode;
 
   // Check if template uses Pug
@@ -122,7 +122,7 @@ function transformVueTemplate(
       ((node: TemplateChildNode) => {
         if (
           !node.loc.source.includes(PathName) &&
-          node.type === VueElementType &&
+          node.type === NodeTypes.ELEMENT &&
           !isEscapeTags(escapeTags, node.tag)
         ) {
           // 向 dom 上添加一个带有 filepath/row/column 的属性

--- a/packages/core/src/server/transform/vue-node-transform.ts
+++ b/packages/core/src/server/transform/vue-node-transform.ts
@@ -1,0 +1,114 @@
+import type {
+  AttributeNode,
+  ElementNode,
+  NodeTransform,
+  SourceLocation,
+  TemplateChildNode,
+  TextNode,
+  TransformContext,
+} from '@vue/compiler-dom';
+import type { EscapeTags, PathType } from '../../shared';
+import {
+  PathName,
+  getMappingFilePath,
+  isEscapeTags,
+  normalizePath,
+} from '../../shared';
+import { getRelativeOrAbsolutePath } from '../server';
+
+const VueElementType = 1;
+const VueTextType = 2;
+const VueAttributeType = 6;
+
+const CodeInspectorEscapeTags = [
+  'style',
+  'script',
+  'template',
+  'transition',
+  'keepalive',
+  'keep-alive',
+  'component',
+  'slot',
+  'teleport',
+  'transition-group',
+  'transitiongroup',
+  'suspense',
+  'fragment',
+];
+
+type VueInspectorNodeTransformOptions = {
+  escapeTags?: EscapeTags;
+  pathType?: PathType;
+  mappings?:
+    | Record<string, string>
+    | Array<{ find: string | RegExp; replacement: string }>;
+};
+
+function hasInspectorPath(node: ElementNode) {
+  return node.props.some(
+    (prop) => prop.type === VueAttributeType && prop.name === PathName,
+  );
+}
+
+function createTextNode(content: string, loc: SourceLocation): TextNode {
+  return {
+    type: VueTextType,
+    content,
+    loc,
+  } as TextNode;
+}
+
+function createAttributeNode(
+  name: string,
+  content: string,
+  loc: SourceLocation,
+): AttributeNode {
+  return {
+    type: VueAttributeType,
+    name,
+    nameLoc: loc,
+    value: createTextNode(content, loc),
+    loc,
+  } as AttributeNode;
+}
+
+function getNodeFilePath(
+  context: TransformContext,
+  options: VueInspectorNodeTransformOptions,
+) {
+  const filename = normalizePath(context.filename || '');
+  const mappedFilePath = getMappingFilePath(filename, options.mappings);
+  return getRelativeOrAbsolutePath(
+    mappedFilePath,
+    options.pathType ?? 'relative',
+  );
+}
+
+export function createVueInspectorNodeTransform(
+  options: VueInspectorNodeTransformOptions = {},
+): NodeTransform {
+  const finalEscapeTags = [
+    ...CodeInspectorEscapeTags,
+    ...(options.escapeTags || []),
+  ];
+
+  return ((node: TemplateChildNode, context: TransformContext) => {
+    if (
+      node.type !== VueElementType ||
+      hasInspectorPath(node) ||
+      isEscapeTags(finalEscapeTags, node.tag)
+    ) {
+      return;
+    }
+
+    const { line, column } = node.loc.start;
+    const filePath = getNodeFilePath(context, options);
+    node.props.unshift(
+      createAttributeNode(
+        PathName,
+        `${filePath}:${line}:${column}:${node.tag}`,
+        node.loc,
+      ),
+    );
+  }) as NodeTransform;
+}

--- a/packages/core/src/server/transform/vue-node-transform.ts
+++ b/packages/core/src/server/transform/vue-node-transform.ts
@@ -7,34 +7,16 @@ import type {
   TextNode,
   TransformContext,
 } from '@vue/compiler-dom';
+import { NodeTypes } from '@vue/compiler-dom';
 import type { EscapeTags, PathType } from '../../shared';
 import {
+  CodeInspectorEscapeTags,
   PathName,
   getMappingFilePath,
   isEscapeTags,
   normalizePath,
 } from '../../shared';
 import { getRelativeOrAbsolutePath } from '../server';
-
-const VueElementType = 1;
-const VueTextType = 2;
-const VueAttributeType = 6;
-
-const CodeInspectorEscapeTags = [
-  'style',
-  'script',
-  'template',
-  'transition',
-  'keepalive',
-  'keep-alive',
-  'component',
-  'slot',
-  'teleport',
-  'transition-group',
-  'transitiongroup',
-  'suspense',
-  'fragment',
-];
 
 type VueInspectorNodeTransformOptions = {
   escapeTags?: EscapeTags;
@@ -46,13 +28,13 @@ type VueInspectorNodeTransformOptions = {
 
 function hasInspectorPath(node: ElementNode) {
   return node.props.some(
-    (prop) => prop.type === VueAttributeType && prop.name === PathName,
+    (prop) => prop.type === NodeTypes.ATTRIBUTE && prop.name === PathName,
   );
 }
 
 function createTextNode(content: string, loc: SourceLocation): TextNode {
   return {
-    type: VueTextType,
+    type: NodeTypes.TEXT,
     content,
     loc,
   } as TextNode;
@@ -64,7 +46,7 @@ function createAttributeNode(
   loc: SourceLocation,
 ): AttributeNode {
   return {
-    type: VueAttributeType,
+    type: NodeTypes.ATTRIBUTE,
     name,
     nameLoc: loc,
     value: createTextNode(content, loc),
@@ -94,7 +76,7 @@ export function createVueInspectorNodeTransform(
 
   return ((node: TemplateChildNode, context: TransformContext) => {
     if (
-      node.type !== VueElementType ||
+      node.type !== NodeTypes.ELEMENT ||
       hasInspectorPath(node) ||
       isEscapeTags(finalEscapeTags, node.tag)
     ) {

--- a/packages/core/src/shared/constant.ts
+++ b/packages/core/src/shared/constant.ts
@@ -6,3 +6,19 @@ export const DefaultPort = 5678;
 export const JsFileExtList = ['.js', '.ts', '.mjs', '.mts', '.jsx', '.tsx'];
 
 export const AstroToolbarFile = '\0astro:dev-toolbar';
+
+export const CodeInspectorEscapeTags = [
+  'style',
+  'script',
+  'template',
+  'transition',
+  'keepalive',
+  'keep-alive',
+  'component',
+  'slot',
+  'teleport',
+  'transition-group',
+  'transitiongroup',
+  'suspense',
+  'fragment',
+];

--- a/packages/core/types/server/index.d.ts
+++ b/packages/core/types/server/index.d.ts
@@ -1,3 +1,3 @@
-export { transformCode } from './transform';
+export { createVueInspectorNodeTransform, transformCode, } from './transform';
 export * from './use-client';
 export * from './server';

--- a/packages/core/types/server/transform/index.d.ts
+++ b/packages/core/types/server/transform/index.d.ts
@@ -1,3 +1,4 @@
+export { createVueInspectorNodeTransform } from './vue-node-transform';
 import { EscapeTags, PathType } from '../../shared';
 type FileType = 'vue' | 'jsx' | 'svelte' | 'astro' | 'mdx' | unknown;
 type TransformCodeParams = {
@@ -9,4 +10,3 @@ type TransformCodeParams = {
     mdx?: boolean;
 };
 export declare function transformCode(params: TransformCodeParams): Promise<string>;
-export {};

--- a/packages/core/types/server/transform/vue-node-transform.d.ts
+++ b/packages/core/types/server/transform/vue-node-transform.d.ts
@@ -1,0 +1,12 @@
+import type { NodeTransform } from '@vue/compiler-dom';
+import type { EscapeTags, PathType } from '../../shared';
+type VueInspectorNodeTransformOptions = {
+    escapeTags?: EscapeTags;
+    pathType?: PathType;
+    mappings?: Record<string, string> | Array<{
+        find: string | RegExp;
+        replacement: string;
+    }>;
+};
+export declare function createVueInspectorNodeTransform(options?: VueInspectorNodeTransformOptions): NodeTransform;
+export {};

--- a/packages/core/types/shared/constant.d.ts
+++ b/packages/core/types/shared/constant.d.ts
@@ -5,3 +5,4 @@ export declare const NodeName = "data-insp-node";
 export declare const DefaultPort = 5678;
 export declare const JsFileExtList: string[];
 export declare const AstroToolbarFile = "\0astro:dev-toolbar";
+export declare const CodeInspectorEscapeTags: string[];

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -1,6 +1,7 @@
 import {
   CodeOptions,
   RecordInfo,
+  createVueInspectorNodeTransform,
   getCodeWithWebComponent,
   getProjectRecord,
   isDev,
@@ -14,10 +15,111 @@ const compatibleDirname = path.dirname(fileURLToPath(import.meta.url));
 
 interface LoaderOptions extends CodeOptions {
   record: RecordInfo;
+  vueCompilerNodeTransform?: boolean;
 }
 
 const baseLoaderPath = path.resolve(compatibleDirname, './loader.js');
 const injectLoaderPath = path.resolve(compatibleDirname, './inject-loader.js');
+const codeInspectorVueNodeTransform = Symbol.for(
+  'code-inspector.vueNodeTransform',
+);
+
+function getUseItems(rule: any): any[] {
+  if (!rule) {
+    return [];
+  }
+
+  if (Array.isArray(rule.use)) {
+    return rule.use;
+  }
+
+  if (rule.loader) {
+    return [rule];
+  }
+
+  return [];
+}
+
+function walkRules(rules: any[], visitor: (rule: any) => void) {
+  rules.forEach((rule) => {
+    visitor(rule);
+    if (Array.isArray(rule.rules)) {
+      walkRules(rule.rules, visitor);
+    }
+    if (Array.isArray(rule.oneOf)) {
+      walkRules(rule.oneOf, visitor);
+    }
+  });
+}
+
+function isVueLoader(loader: string) {
+  return /(^|[\\/])vue-loader([\\/]|$)/.test(loader);
+}
+
+function isVueTemplateLoader(loader: string) {
+  return /(^|[\\/])vue-loader[\\/]dist[\\/]templateLoader\.js$/.test(loader);
+}
+
+function applyVueCompilerNodeTransform(options: CodeOptions, compiler: any) {
+  const _compiler = compiler?.compiler || compiler;
+  const module = _compiler?.options?.module;
+  const rules = module?.rules || module?.loaders || [];
+  let applied = false;
+
+  walkRules(rules, (rule) => {
+    getUseItems(rule).forEach((item) => {
+      const loader = typeof item === 'string' ? item : item?.loader;
+      if (
+        typeof loader !== 'string' ||
+        (!isVueLoader(loader) && !isVueTemplateLoader(loader))
+      ) {
+        return;
+      }
+
+      if (typeof item === 'string') {
+        return;
+      }
+
+      if (!item.options || typeof item.options !== 'object') {
+        item.options = {};
+      }
+
+      const loaderOptions = item.options;
+      if (
+        !loaderOptions.compilerOptions ||
+        typeof loaderOptions.compilerOptions !== 'object'
+      ) {
+        loaderOptions.compilerOptions = {};
+      }
+
+      const compilerOptions = loaderOptions.compilerOptions;
+      if (!Array.isArray(compilerOptions.nodeTransforms)) {
+        compilerOptions.nodeTransforms = [];
+      }
+
+      const nodeTransforms = compilerOptions.nodeTransforms;
+      const hasRegistered = nodeTransforms.some(
+        (transform: any) => transform?.[codeInspectorVueNodeTransform],
+      );
+
+      if (!hasRegistered) {
+        const transform = createVueInspectorNodeTransform({
+          escapeTags: options.escapeTags,
+          mappings: options.mappings,
+          pathType: options.pathType,
+        });
+        Object.defineProperty(transform, codeInspectorVueNodeTransform, {
+          value: true,
+        });
+        nodeTransforms.push(transform);
+      }
+
+      applied = true;
+    });
+  });
+
+  return applied;
+}
 
 function hasRegisteredCodeInspectorLoader(rules: any[]) {
   return rules.some((rule) =>
@@ -165,14 +267,18 @@ class WebpackCodeInspectorPlugin {
       if (this.options.cache) {
         // 用来在 cache 情况下启动 node server
         record.port =
-          this.options.port || getProjectRecord(record)?.previousPort;
+            this.options.port || getProjectRecord(record)?.previousPort || 0;
         getPureClientCodeString(this.options, record, true);
       } else {
         cache.version = `code-inspector-${Date.now()}`;
       }
     }
 
-    applyLoader({ ...this.options, record }, compiler);
+    const vueCompilerNodeTransform = applyVueCompilerNodeTransform(
+      this.options,
+      compiler,
+    );
+    applyLoader({ ...this.options, record, vueCompilerNodeTransform }, compiler);
 
     if (
       compiler?.hooks?.emit &&

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -25,10 +25,6 @@ const codeInspectorVueNodeTransform = Symbol.for(
 );
 
 function getUseItems(rule: any): any[] {
-  if (!rule) {
-    return [];
-  }
-
   if (Array.isArray(rule.use)) {
     return rule.use;
   }
@@ -42,6 +38,9 @@ function getUseItems(rule: any): any[] {
 
 function walkRules(rules: any[], visitor: (rule: any) => void) {
   rules.forEach((rule) => {
+    if (!rule) {
+      return;
+    }
     visitor(rule);
     if (Array.isArray(rule.rules)) {
       walkRules(rule.rules, visitor);

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -52,6 +52,13 @@ function walkRules(rules: any[], visitor: (rule: any) => void) {
   });
 }
 
+// Resolve module.rules across webpack/rspack versions and child compilers.
+function getCompilerRules(compiler: any): any[] {
+  const _compiler = compiler?.compiler || compiler;
+  const module = _compiler?.options?.module;
+  return module?.rules || module?.loaders || [];
+}
+
 function isVueLoader(loader: string) {
   return /(^|[\\/])vue-loader([\\/]|$)/.test(loader);
 }
@@ -61,9 +68,7 @@ function isVueTemplateLoader(loader: string) {
 }
 
 function applyVueCompilerNodeTransform(options: CodeOptions, compiler: any) {
-  const _compiler = compiler?.compiler || compiler;
-  const module = _compiler?.options?.module;
-  const rules = module?.rules || module?.loaders || [];
+  const rules = getCompilerRules(compiler);
   let applied = false;
 
   walkRules(rules, (rule) => {
@@ -131,10 +136,7 @@ function hasRegisteredCodeInspectorLoader(rules: any[]) {
 }
 
 const applyLoader = (options: LoaderOptions, compiler: any) => {
-  // 适配 webpack 各个版本
-  const _compiler = compiler?.compiler || compiler;
-  const module = _compiler?.options?.module;
-  const rules = module?.rules || module?.loaders || [];
+  const rules = getCompilerRules(compiler);
 
   if (hasRegisteredCodeInspectorLoader(rules)) {
     return;
@@ -267,7 +269,7 @@ class WebpackCodeInspectorPlugin {
       if (this.options.cache) {
         // 用来在 cache 情况下启动 node server
         record.port =
-            this.options.port || getProjectRecord(record)?.previousPort || 0;
+          this.options.port || getProjectRecord(record)?.previousPort || 0;
         getPureClientCodeString(this.options, record, true);
       } else {
         cache.version = `code-inspector-${Date.now()}`;
@@ -278,7 +280,10 @@ class WebpackCodeInspectorPlugin {
       this.options,
       compiler,
     );
-    applyLoader({ ...this.options, record, vueCompilerNodeTransform }, compiler);
+    applyLoader(
+      { ...this.options, record, vueCompilerNodeTransform },
+      compiler,
+    );
 
     if (
       compiler?.hooks?.emit &&

--- a/packages/webpack/src/loader.ts
+++ b/packages/webpack/src/loader.ts
@@ -79,6 +79,9 @@ async function transformWebpackCodeInspectorContent(
     filePath.endsWith('.html') &&
     params.get('type') === 'template' &&
     params.has('vue');
+  if (options.vueCompilerNodeTransform && (isVue || isHtmlVue)) {
+    return content;
+  }
   if (isVue || isHtmlVue) {
     return await transformCode({
       content,

--- a/test/core/server/transform/transform-vue.test.ts
+++ b/test/core/server/transform/transform-vue.test.ts
@@ -1,15 +1,26 @@
 import { describe, it, expect, vi } from 'vitest';
 import fs from 'fs';
+import { createRequire } from 'node:module';
 import {
   resolveVueCompilerDom,
   transformVue,
 } from '@/core/src/server/transform/transform-vue';
+import {
+  createVueInspectorNodeTransform,
+} from '@/core/src/server/transform/vue-node-transform';
 import { PathName } from '@/core/src/shared/constant';
 
 // Only mock server module, not fs
 vi.mock('@/core/src/server/server', () => ({
   ProjectRootPath: '/mock/project',
+  getRelativeOrAbsolutePath: (filePath: string, pathType?: string) =>
+    pathType === 'relative'
+      ? filePath.replace('/mock/project/', '')
+      : filePath,
 }));
+
+const coreRequire = createRequire(`${process.cwd()}/packages/core/package.json`);
+const { compile } = coreRequire('@vue/compiler-dom') as { compile: any };
 
 describe('transformVue', () => {
   const filePath = 'test/file.vue';
@@ -702,5 +713,46 @@ const count = ref(0);
         }),
       ).toThrowError('Failed to load @vue/compiler-dom parse/transform exports');
     });
+  });
+});
+
+describe('createVueInspectorNodeTransform', () => {
+  it('should inject data-insp-path through Vue compiler AST without changing source', () => {
+    const source = '<div><span>Hi</span></div>';
+    const result = compile(source, {
+      filename: '/mock/project/src/App.vue',
+      nodeTransforms: [
+        createVueInspectorNodeTransform({
+          pathType: 'relative',
+        }),
+      ],
+    });
+
+    expect(source).toBe('<div><span>Hi</span></div>');
+    expect(result.code).toContain(
+      `"${PathName}": "src/App.vue:1:1:div"`,
+    );
+    expect(result.code).toContain(
+      `"${PathName}": "src/App.vue:1:6:span"`,
+    );
+  });
+
+  it('should respect escapeTags and existing data-insp-path attributes', () => {
+    const result = compile(
+      `<div ${PathName}="existing"><custom-card>Skip</custom-card></div>`,
+      {
+        filename: '/mock/project/src/App.vue',
+        nodeTransforms: [
+          createVueInspectorNodeTransform({
+            escapeTags: [/^custom-/],
+            pathType: 'relative',
+          }),
+        ],
+      },
+    );
+
+    expect(result.code.match(new RegExp(PathName, 'g'))?.length).toBe(1);
+    expect(result.code).toContain(`"${PathName}": "existing"`);
+    expect(result.code).not.toContain(':custom-card');
   });
 });

--- a/test/core/server/transform/transform-vue.test.ts
+++ b/test/core/server/transform/transform-vue.test.ts
@@ -755,4 +755,29 @@ describe('createVueInspectorNodeTransform', () => {
     expect(result.code).toContain(`"${PathName}": "existing"`);
     expect(result.code).not.toContain(':custom-card');
   });
+
+  it('should default pathType to relative and apply mappings', () => {
+    const result = compile('<div>mapped</div>', {
+      filename: '/mock/project/src/App.vue',
+      nodeTransforms: [
+        createVueInspectorNodeTransform({
+          // no pathType -> defaults to 'relative'
+          mappings: [{ find: '/mock/project/', replacement: '/mapped/' }],
+        }),
+      ],
+    });
+
+    // mapping target does not exist on disk, so path is unchanged then made relative
+    expect(result.code).toContain(`"${PathName}": "src/App.vue:1:1:div"`);
+  });
+
+  it('should handle empty filename gracefully', () => {
+    const result = compile('<div>no filename</div>', {
+      // no filename -> context.filename is empty -> defaults to ''
+      nodeTransforms: [createVueInspectorNodeTransform({ pathType: 'relative' })],
+    });
+
+    // normalizePath('') resolves to '.', so path becomes '.'
+    expect(result.code).toContain(`"${PathName}": ".:1:1:div"`);
+  });
 });

--- a/test/webpack/index.test.ts
+++ b/test/webpack/index.test.ts
@@ -176,6 +176,125 @@ describe('WebpackCodeInspectorPlugin', () => {
         true,
       );
     });
+
+    it('should initialize compilerOptions when not present on vue-loader options', async () => {
+      vi.mocked(isDev).mockReturnValueOnce(true);
+      const vueLoaderOptions = {};
+      mockCompiler.options.module.rules.push({
+        test: /\.vue$/,
+        use: [
+          {
+            loader: '/test/node_modules/vue-loader/dist/index.js',
+            options: vueLoaderOptions,
+          },
+        ],
+      });
+
+      const plugin = new WebpackCodeInspectorPlugin({
+        bundler: 'webpack',
+        output: '/test',
+      });
+      await plugin.apply(mockCompiler);
+
+      expect(vueLoaderOptions.compilerOptions).toBeDefined();
+      expect(vueLoaderOptions.compilerOptions.nodeTransforms).toHaveLength(1);
+    });
+
+    it('should initialize nodeTransforms array when not present', async () => {
+      vi.mocked(isDev).mockReturnValueOnce(true);
+      const vueLoaderOptions = { compilerOptions: {} };
+      mockCompiler.options.module.rules.push({
+        test: /\.vue$/,
+        use: [
+          {
+            loader: '/test/node_modules/vue-loader/dist/index.js',
+            options: vueLoaderOptions,
+          },
+        ],
+      });
+
+      const plugin = new WebpackCodeInspectorPlugin({
+        bundler: 'webpack',
+        output: '/test',
+      });
+      await plugin.apply(mockCompiler);
+
+      expect(Array.isArray(vueLoaderOptions.compilerOptions.nodeTransforms)).toBe(true);
+      expect(vueLoaderOptions.compilerOptions.nodeTransforms).toHaveLength(1);
+    });
+
+    it('should initialize options object when not present on vue-loader use item', async () => {
+      vi.mocked(isDev).mockReturnValueOnce(true);
+      const useItem: any = {
+        loader: '/test/node_modules/vue-loader/dist/index.js',
+      };
+      mockCompiler.options.module.rules.push({
+        test: /\.vue$/,
+        use: [useItem],
+      });
+
+      const plugin = new WebpackCodeInspectorPlugin({
+        bundler: 'webpack',
+        output: '/test',
+      });
+      await plugin.apply(mockCompiler);
+
+      expect(useItem.options).toBeDefined();
+      expect(useItem.options.compilerOptions.nodeTransforms).toHaveLength(1);
+    });
+
+    it('should walk nested rules (oneOf/rules) and skip string loaders', async () => {
+      vi.mocked(isDev).mockReturnValueOnce(true);
+      const vueLoaderOptions = { compilerOptions: { nodeTransforms: [] } };
+      mockCompiler.options.module.rules.push({
+        oneOf: [
+          {
+            rules: [
+              {
+                use: [
+                  // string loader matching vue-loader -> skipped (typeof string)
+                  'vue-loader',
+                  {
+                    loader: '/test/node_modules/vue-loader/dist/index.js',
+                    options: vueLoaderOptions,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      const plugin = new WebpackCodeInspectorPlugin({
+        bundler: 'webpack',
+        output: '/test',
+      });
+      await plugin.apply(mockCompiler);
+
+      expect(vueLoaderOptions.compilerOptions.nodeTransforms).toHaveLength(1);
+    });
+
+    it('should handle rule.loader shorthand and falsy rule entries', async () => {
+      vi.mocked(isDev).mockReturnValueOnce(true);
+      const vueLoaderOptions = { compilerOptions: { nodeTransforms: [] } };
+      mockCompiler.options.module.rules.push(
+        // falsy rule entry -> getUseItems returns []
+        null,
+        // rule.loader shorthand (no `use` array) -> getUseItems returns [rule]
+        {
+          loader: '/test/node_modules/vue-loader/dist/index.js',
+          options: vueLoaderOptions,
+        },
+      );
+
+      const plugin = new WebpackCodeInspectorPlugin({
+        bundler: 'webpack',
+        output: '/test',
+      });
+      await plugin.apply(mockCompiler);
+
+      expect(vueLoaderOptions.compilerOptions.nodeTransforms).toHaveLength(1);
+    });
   });
 
   describe('filesystem cache handling', () => {
@@ -208,6 +327,22 @@ describe('WebpackCodeInspectorPlugin', () => {
       await plugin.apply(mockCompiler);
 
       expect(mockCompiler.options.cache.version).toMatch(/^code-inspector-/);
+    });
+
+    it('should default record.port to 0 when no port and no previousPort', async () => {
+      vi.mocked(isDev).mockReturnValueOnce(true);
+      mockCompiler.options.cache = { type: 'filesystem' };
+      vi.mocked(getProjectRecord).mockReturnValueOnce({ previousPort: 0 } as any);
+
+      const plugin = new WebpackCodeInspectorPlugin({
+        bundler: 'webpack',
+        output: '/test',
+        cache: true,
+      });
+
+      await plugin.apply(mockCompiler);
+
+      expect(getProjectRecord).toHaveBeenCalled();
     });
 
     it('should use previousPort when port is not specified', async () => {

--- a/test/webpack/index.test.ts
+++ b/test/webpack/index.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@code-inspector/core', () => ({
   CodeOptions: {},
   RecordInfo: {},
+  createVueInspectorNodeTransform: vi.fn(() => vi.fn()),
   fileURLToPath: vi.fn((url: string) => url.replace('file://', '')),
   getCodeWithWebComponent: vi.fn(async () => 'injected-code'),
   getProjectRecord: vi.fn(() => ({ previousPort: 3000 })),
@@ -28,6 +29,7 @@ vi.mock('@/webpack/src/entry', () => ({
 
 import WebpackCodeInspectorPlugin from '@/webpack/src/index';
 import {
+  createVueInspectorNodeTransform,
   getCodeWithWebComponent,
   getProjectRecord,
   isDev,
@@ -130,6 +132,49 @@ describe('WebpackCodeInspectorPlugin', () => {
       await plugin.apply(mockCompiler);
 
       expect(mockCompiler.options.module.rules.length).toBeGreaterThan(0);
+    });
+
+    it('should register Vue compiler node transform on vue-loader options', async () => {
+      vi.mocked(isDev).mockReturnValueOnce(true);
+      const vueLoaderOptions = {
+        compilerOptions: {
+          nodeTransforms: [],
+        },
+      };
+      mockCompiler.options.module.rules.push({
+        test: /\.vue$/,
+        use: [
+          {
+            loader: '/test/node_modules/vue-loader/dist/index.js',
+            options: vueLoaderOptions,
+          },
+        ],
+      });
+
+      const plugin = new WebpackCodeInspectorPlugin({
+        bundler: 'webpack',
+        output: '/test',
+        pathType: 'relative',
+      });
+
+      await plugin.apply(mockCompiler);
+
+      expect(createVueInspectorNodeTransform).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pathType: 'relative',
+        }),
+      );
+      expect(vueLoaderOptions.compilerOptions.nodeTransforms).toHaveLength(1);
+
+      const codeInspectorRule = mockCompiler.options.module.rules.find(
+        (rule: any) =>
+          rule?.use?.some?.((item: any) =>
+            item?.loader?.includes?.('loader.js'),
+          ),
+      );
+      expect(codeInspectorRule.use[0].options.vueCompilerNodeTransform).toBe(
+        true,
+      );
     });
   });
 
@@ -484,7 +529,9 @@ describe('WebpackCodeInspectorPlugin', () => {
       process.env.NODE_ENV = 'development';
       mockCompiler.options.mode = undefined;
 
-      vi.mocked(isDev).mockImplementation((dev, condition) => dev ?? condition);
+        vi.mocked(isDev).mockImplementation((dev, condition) =>
+          typeof dev === 'function' ? dev() : (dev ?? condition),
+        );
 
       const plugin = new WebpackCodeInspectorPlugin({
         bundler: 'webpack',

--- a/test/webpack/loader.test.ts
+++ b/test/webpack/loader.test.ts
@@ -23,6 +23,15 @@ import {
   isExcludedFile,
 } from '@code-inspector/core';
 
+function callLoader(
+  context: any,
+  content: string,
+  source?: any,
+  meta?: any,
+) {
+  return WebpackCodeInspectorLoader.call(context, content, source, meta);
+}
+
 describe('WebpackCodeInspectorLoader', () => {
   let mockContext: any;
 
@@ -42,13 +51,13 @@ describe('WebpackCodeInspectorLoader', () => {
 
   describe('caching', () => {
     it('should call cacheable when available', async () => {
-      const result = await WebpackCodeInspectorLoader.call(mockContext, 'const x = 1;');
+      const result = await callLoader(mockContext, 'const x = 1;');
       expect(mockContext.cacheable).toHaveBeenCalledWith(true);
     });
 
     it('should work when cacheable is not available', async () => {
       delete mockContext.cacheable;
-      const result = await WebpackCodeInspectorLoader.call(mockContext, 'const x = 1;');
+      const result = await callLoader(mockContext, 'const x = 1;');
       expect(result).toBeDefined();
     });
 
@@ -59,7 +68,7 @@ describe('WebpackCodeInspectorLoader', () => {
         const callback = vi.fn((...args: any[]) => resolve(args));
         mockContext.async = vi.fn(() => callback);
 
-        const result = WebpackCodeInspectorLoader.call(
+        const result = callLoader(
           mockContext,
           'const x = 1;',
           source,
@@ -83,7 +92,7 @@ describe('WebpackCodeInspectorLoader', () => {
     it('should return original content for excluded files', async () => {
       vi.mocked(isExcludedFile).mockReturnValueOnce(true);
       const content = 'const x = 1;';
-      const result = await WebpackCodeInspectorLoader.call(mockContext, content);
+      const result = await callLoader(mockContext, content);
       expect(result).toBe(content);
     });
   });
@@ -94,7 +103,7 @@ describe('WebpackCodeInspectorLoader', () => {
       mockContext.resource = '/test/file.tsx';
       vi.mocked(isJsTypeFile).mockReturnValueOnce(true);
 
-      const result = await WebpackCodeInspectorLoader.call(mockContext, 'const x = 1;');
+      const result = await callLoader(mockContext, 'const x = 1;');
       expect(transformCode).toHaveBeenCalledWith(
         expect.objectContaining({
           fileType: 'jsx',
@@ -107,7 +116,7 @@ describe('WebpackCodeInspectorLoader', () => {
       mockContext.resource = '/test/file.vue?isJsx';
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
-      const result = await WebpackCodeInspectorLoader.call(mockContext, 'const x = 1;');
+      const result = await callLoader(mockContext, 'const x = 1;');
       expect(transformCode).toHaveBeenCalledWith(
         expect.objectContaining({
           fileType: 'jsx',
@@ -120,7 +129,7 @@ describe('WebpackCodeInspectorLoader', () => {
       mockContext.resource = '/test/file.vue?isTsx';
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
-      const result = await WebpackCodeInspectorLoader.call(mockContext, 'const x = 1;');
+      const result = await callLoader(mockContext, 'const x = 1;');
       expect(transformCode).toHaveBeenCalled();
     });
 
@@ -129,7 +138,7 @@ describe('WebpackCodeInspectorLoader', () => {
       mockContext.resource = '/test/file.vue?lang.jsx';
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
-      const result = await WebpackCodeInspectorLoader.call(mockContext, 'const x = 1;');
+      const result = await callLoader(mockContext, 'const x = 1;');
       expect(transformCode).toHaveBeenCalled();
     });
 
@@ -138,7 +147,7 @@ describe('WebpackCodeInspectorLoader', () => {
       mockContext.resource = '/test/file.vue?lang.tsx';
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
-      const result = await WebpackCodeInspectorLoader.call(mockContext, 'const x = 1;');
+      const result = await callLoader(mockContext, 'const x = 1;');
       expect(transformCode).toHaveBeenCalled();
     });
   });
@@ -150,7 +159,7 @@ describe('WebpackCodeInspectorLoader', () => {
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
       const content = '<template></template><script lang="tsx">const a = 1;</script>';
-      const result = await WebpackCodeInspectorLoader.call(mockContext, content);
+      const result = await callLoader(mockContext, content);
       expect(parseSFC).toHaveBeenCalled();
     });
 
@@ -160,7 +169,7 @@ describe('WebpackCodeInspectorLoader', () => {
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
       const content = '<template></template><script lang="jsx">const a = 1;</script>';
-      const result = await WebpackCodeInspectorLoader.call(mockContext, content);
+      const result = await callLoader(mockContext, content);
       expect(parseSFC).toHaveBeenCalled();
     });
 
@@ -176,7 +185,7 @@ describe('WebpackCodeInspectorLoader', () => {
       } as any);
 
       const content = '<script lang="tsx">const a = 1;</script>';
-      const result = await WebpackCodeInspectorLoader.call(mockContext, content);
+      const result = await callLoader(mockContext, content);
       expect(transformCode).toHaveBeenCalled();
     });
 
@@ -192,7 +201,7 @@ describe('WebpackCodeInspectorLoader', () => {
       } as any);
 
       const content = '<script setup lang="tsx">const b = 2;</script>';
-      const result = await WebpackCodeInspectorLoader.call(mockContext, content);
+      const result = await callLoader(mockContext, content);
       expect(transformCode).toHaveBeenCalled();
     });
   });
@@ -203,7 +212,7 @@ describe('WebpackCodeInspectorLoader', () => {
       mockContext.resource = '/test/file.vue';
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
-      const result = await WebpackCodeInspectorLoader.call(mockContext, '<template></template>');
+      const result = await callLoader(mockContext, '<template></template>');
       expect(transformCode).toHaveBeenCalledWith(
         expect.objectContaining({
           fileType: 'vue',
@@ -216,7 +225,7 @@ describe('WebpackCodeInspectorLoader', () => {
       mockContext.resource = '/test/template.html?type=template&vue';
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
-      const result = await WebpackCodeInspectorLoader.call(mockContext, '<div></div>');
+      const result = await callLoader(mockContext, '<div></div>');
       expect(transformCode).toHaveBeenCalledWith(
         expect.objectContaining({
           fileType: 'vue',
@@ -230,7 +239,7 @@ describe('WebpackCodeInspectorLoader', () => {
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
       const content = '.class { color: red; }';
-      const result = await WebpackCodeInspectorLoader.call(mockContext, content);
+      const result = await callLoader(mockContext, content);
       expect(result).toBe(content);
     });
 
@@ -240,7 +249,7 @@ describe('WebpackCodeInspectorLoader', () => {
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
       const content = 'export default {}';
-      const result = await WebpackCodeInspectorLoader.call(mockContext, content);
+      const result = await callLoader(mockContext, content);
       expect(result).toBe(content);
     });
 
@@ -250,7 +259,7 @@ describe('WebpackCodeInspectorLoader', () => {
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
       const content = '<template></template>';
-      const result = await WebpackCodeInspectorLoader.call(mockContext, content);
+      const result = await callLoader(mockContext, content);
       expect(result).toBe(content);
     });
   });
@@ -261,12 +270,28 @@ describe('WebpackCodeInspectorLoader', () => {
       mockContext.resource = '/test/file.svelte';
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
-      const result = await WebpackCodeInspectorLoader.call(mockContext, '<div></div>');
+      const result = await callLoader(mockContext, '<div></div>');
       expect(transformCode).toHaveBeenCalledWith(
         expect.objectContaining({
           fileType: 'svelte',
         })
       );
+    });
+
+    it('should skip Vue template string transform when compiler node transform is enabled', async () => {
+      mockContext.resourcePath = '/test/file.vue';
+      mockContext.resource = '/test/file.vue?vue&type=template&id=abc';
+      mockContext.query.vueCompilerNodeTransform = true;
+      vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
+
+      const content = '<section>Static</section>';
+      const result = await callLoader(
+        mockContext,
+        content,
+      );
+
+      expect(result).toBe(content);
+      expect(transformCode).not.toHaveBeenCalled();
     });
   });
 
@@ -277,7 +302,7 @@ describe('WebpackCodeInspectorLoader', () => {
       vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
 
       const content = '.class { color: red; }';
-      const result = await WebpackCodeInspectorLoader.call(mockContext, content);
+      const result = await callLoader(mockContext, content);
       expect(result).toBe(content);
     });
   });
@@ -289,7 +314,7 @@ describe('WebpackCodeInspectorLoader', () => {
       mockContext.resource = '/test/file.tsx';
       vi.mocked(isJsTypeFile).mockReturnValueOnce(true);
 
-      const result = await WebpackCodeInspectorLoader.call(mockContext, 'const x = 1;');
+      const result = await callLoader(mockContext, 'const x = 1;');
       expect(result).toBeDefined();
     });
 
@@ -299,7 +324,7 @@ describe('WebpackCodeInspectorLoader', () => {
       mockContext.resource = '/test/file.tsx';
       vi.mocked(isJsTypeFile).mockReturnValueOnce(true);
 
-      const result = await WebpackCodeInspectorLoader.call(
+      const result = await callLoader(
         mockContext,
         'const x = 1;',
       );

--- a/test/webpack/loader.test.ts
+++ b/test/webpack/loader.test.ts
@@ -293,6 +293,19 @@ describe('WebpackCodeInspectorLoader', () => {
       expect(result).toBe(content);
       expect(transformCode).not.toHaveBeenCalled();
     });
+
+    it('should skip html-vue template transform when compiler node transform is enabled', async () => {
+      mockContext.resourcePath = '/test/file.html';
+      mockContext.resource = '/test/file.html?type=template&vue';
+      mockContext.query.vueCompilerNodeTransform = true;
+      vi.mocked(isJsTypeFile).mockReturnValueOnce(false);
+
+      const content = '<section>Static</section>';
+      const result = await callLoader(mockContext, content);
+
+      expect(result).toBe(content);
+      expect(transformCode).not.toHaveBeenCalled();
+    });
   });
 
   describe('other files', () => {


### PR DESCRIPTION
## Background

Fixes #547. In production builds, the webpack/rspack pre-loader rewrote `.vue` SFC source strings to inject `data-insp-path`, which caused vue-loader/rspack-vue-loader to compute inconsistent `scopeId` values between hoisted template `data-v-xxx` and the component `__scopeId`, breaking scoped CSS. Additionally `data-insp-path` was not reliably injected.

## Changes

### 1. Fix (from PR #548)
Inject `data-insp-path` via the Vue compiler `nodeTransforms` AST hook instead of rewriting source strings, so the source is untouched and scopeId computation is unaffected.

- `packages/core/src/server/transform/vue-node-transform.ts`: new `createVueInspectorNodeTransform(options)` returning a `NodeTransform` that injects the attribute on element nodes.
- `packages/webpack/src/index.ts`: `applyVueCompilerNodeTransform` walks `module.rules`, finds vue-loader and injects the transform into `compilerOptions.nodeTransforms` (idempotent via `Symbol.for`).
- `packages/webpack/src/loader.ts`: when `vueCompilerNodeTransform` is enabled, skip string rewriting for `.vue` / html-vue.

## Verification

- `tsc` passes for all modified packages.
- Full test suite: **79 files / 1045 tests passed**.