### PR TITLE
fix: handle rspack persistent cache

### DIFF
--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -250,8 +250,8 @@ class WebpackCodeInspectorPlugin {
     // webpack cache || rspack persistent cache
     const cache =
       compiler?.options?.cache || compiler?.options?.experiments?.cache;
-    // webpack file system cache
-    if (cache?.type === 'filesystem') {
+    // webpack filesystem cache || rspack persistent cache
+    if (cache?.type === 'filesystem' || cache?.type === 'persistent') {
       if (this.options.cache) {
         // 用来在 cache 情况下启动 node server
         record.port =

--- a/test/webpack/index.test.ts
+++ b/test/webpack/index.test.ts
@@ -698,9 +698,40 @@ describe('WebpackCodeInspectorPlugin', () => {
   });
 
   describe('rspack persistent cache', () => {
-    it('should handle rspack experiments.cache', async () => {
+    it('should handle rspack persistent cache', async () => {
       vi.mocked(isDev).mockReturnValueOnce(true);
-      mockCompiler.options.experiments = { cache: { type: 'filesystem' } };
+      mockCompiler.options.cache = { type: 'persistent' };
+
+      const plugin = new WebpackCodeInspectorPlugin({
+        bundler: 'rspack',
+        output: '/test',
+        cache: true,
+      });
+
+      await plugin.apply(mockCompiler);
+
+      expect(getCodeWithWebComponent).toHaveBeenCalled();
+    });
+
+    it('should set rspack persistent cache version when cache option is disabled', async () => {
+      vi.mocked(isDev).mockReturnValueOnce(true);
+      mockCompiler.options.cache = { type: 'persistent' };
+
+      const plugin = new WebpackCodeInspectorPlugin({
+        bundler: 'rspack',
+        output: '/test',
+        cache: false,
+      });
+
+      await plugin.apply(mockCompiler);
+
+      expect(mockCompiler.options.cache.version).toMatch(/^code-inspector-/);
+    });
+
+    it('should support legacy rspack experiments.cache', async () => {
+      vi.mocked(isDev).mockReturnValueOnce(true);
+      mockCompiler.options.cache = false;
+      mockCompiler.options.experiments = { cache: { type: 'persistent' } };
 
       const plugin = new WebpackCodeInspectorPlugin({
         bundler: 'rspack',


### PR DESCRIPTION
## Summary

- Handle Rspack persistent cache by recognizing `cache.type === 'persistent'`.
- Keep existing webpack filesystem cache behavior unchanged.
- Add regression coverage for Rspack top-level persistent cache and legacy `experiments.cache`.

## Test plan

- `./node_modules/.bin/vitest run test/webpack/index.test.ts`