### PR TITLE
fix: refine AI light theme colors

### DIFF
--- a/packages/core/src/ai/client/ai-terminal.ts
+++ b/packages/core/src/ai/client/ai-terminal.ts
@@ -107,28 +107,28 @@ const DARK_THEME: ITheme = {
 };
 
 const LIGHT_THEME: ITheme = {
-  background: '#eceff4',
-  foreground: '#2e3440',
-  cursor: '#5e81ac',
-  cursorAccent: '#eceff4',
-  selectionBackground: '#d8dee9',
+  background: '#fafaf9',
+  foreground: '#242424',
+  cursor: '#006aff',
+  cursorAccent: '#fafaf9',
+  selectionBackground: '#dedbd4',
   selectionForeground: '#000000',
   black: '#3b4252',
-  red: '#a34b5c',
-  green: '#5f7a60',
-  yellow: '#8f6f3e',
-  blue: '#4c6f97',
-  magenta: '#8a5d83',
-  cyan: '#4f8a94',
+  red: '#cf222e',
+  green: '#1a7f37',
+  yellow: '#9a6700',
+  blue: '#006aff',
+  magenta: '#9b37b7',
+  cyan: '#087ea4',
   white: '#7b88a1',
   brightBlack: '#4c566a',
-  brightRed: '#8f3f4f',
-  brightGreen: '#4f6b53',
-  brightYellow: '#7a5f33',
-  brightBlue: '#3f5f84',
-  brightMagenta: '#744c70',
-  brightCyan: '#3f727b',
-  brightWhite: '#d8dee9',
+  brightRed: '#e5534b',
+  brightGreen: '#2da44e',
+  brightYellow: '#bf8700',
+  brightBlue: '#0057d9',
+  brightMagenta: '#bf4bce',
+  brightCyan: '#0a95b8',
+  brightWhite: '#f4f4f2',
 };
 
 function terminalThemeFor(theme: 'dark' | 'light'): ITheme {
@@ -138,18 +138,18 @@ function terminalThemeFor(theme: 'dark' | 'light'): ITheme {
 function terminalBackgroundFor(theme: 'dark' | 'light'): string {
   return (
     terminalThemeFor(theme).background ||
-    (theme === 'dark' ? '#2e3440' : '#eceff4')
+    (theme === 'dark' ? '#2e3440' : '#fafaf9')
   );
 }
 
 function terminalCursorFor(theme: 'dark' | 'light'): string {
   return (
-    terminalThemeFor(theme).cursor || (theme === 'dark' ? '#88c0d0' : '#5e81ac')
+    terminalThemeFor(theme).cursor || (theme === 'dark' ? '#88c0d0' : '#006aff')
   );
 }
 
-const LIGHT_SURFACE_BACKGROUND_RGB = [236, 239, 244] as const;
-const LIGHT_FOREGROUND_RGB = [46, 52, 64] as const;
+const LIGHT_SURFACE_BACKGROUND_RGB = [250, 250, 249] as const;
+const LIGHT_FOREGROUND_RGB = [36, 36, 36] as const;
 const DARK_SURFACE_BACKGROUND_RGB = [46, 52, 64] as const;
 const DARK_FOREGROUND_RGB = [216, 222, 233] as const;
 const DARK_BACKGROUND_THRESHOLD = 64;

--- a/packages/core/src/ai/client/ai.ts
+++ b/packages/core/src/ai/client/ai.ts
@@ -1973,51 +1973,51 @@ export const chatStyles = css`
 
   /* 亮色主题变量 */
   :host(.chat-theme-light) {
-    --chat-bg: #eceff4;
-    --chat-header-bg: #e5e9f0;
-    --chat-border: #c7d0dd;
-    --chat-text: #2e3440;
-    --chat-text-primary: #2e3440;
-    --chat-text-secondary: #434c5e;
-    --chat-text-muted: #4c566a;
-    --chat-text-placeholder: #5e6b82;
-    --chat-accent: #4c6f97;
-    --chat-accent-hover: #3f5f84;
-    --chat-overlay: rgba(46, 52, 64, 0.16);
-    --chat-shadow: rgba(46, 52, 64, 0.14);
-    --chat-code-bg: #e5e9f0;
-    --chat-code-text: #a34b5c;
-    --chat-pre-bg: #e5e9f0;
-    --chat-pre-text: #2e3440;
-    --chat-prompt-ai: #8a5d83;
-    --chat-tool-bg: #e5e9f0;
-    --chat-tool-border: #c7d0dd;
-    --chat-tool-complete: #5f7a60;
-    --chat-tool-name: #8f6f3e;
-    --chat-tool-result: #4c6f97;
-    --chat-tool-error: #a34b5c;
-    --chat-tool-prefix: #6b778c;
-    --chat-scrollbar-track: #eceff4;
-    --chat-scrollbar-thumb: #c7d0dd;
-    --chat-scrollbar-hover: #a7b1c2;
-    --chat-heading: #2e3440;
-    --chat-strong: #2e3440;
-    --chat-em: #434c5e;
-    --chat-del: #6b778c;
-    --chat-blockquote-bg: #e5e9f0;
-    --chat-blockquote-text: #434c5e;
-    --chat-table-header-bg: #e5e9f0;
-    --chat-table-alt-bg: #e7ebf1;
-    --chat-input-bg: #eceff4;
+    --chat-bg: #fafaf9;
+    --chat-header-bg: #f4f4f2;
+    --chat-border: #d8d6d1;
+    --chat-text: #242424;
+    --chat-text-primary: #1f1f1f;
+    --chat-text-secondary: #4b4b47;
+    --chat-text-muted: #6f6d67;
+    --chat-text-placeholder: #7a776f;
+    --chat-accent: #006aff;
+    --chat-accent-hover: #0057d9;
+    --chat-overlay: rgba(36, 36, 36, 0.12);
+    --chat-shadow: rgba(36, 36, 36, 0.13);
+    --chat-code-bg: #f1f1ef;
+    --chat-code-text: #cf222e;
+    --chat-pre-bg: #f1f1ef;
+    --chat-pre-text: #242424;
+    --chat-prompt-ai: #9b37b7;
+    --chat-tool-bg: #f1f1ef;
+    --chat-tool-border: #d8d6d1;
+    --chat-tool-complete: #1a7f37;
+    --chat-tool-name: #9a6700;
+    --chat-tool-result: #006aff;
+    --chat-tool-error: #cf222e;
+    --chat-tool-prefix: #656d76;
+    --chat-scrollbar-track: #fafaf9;
+    --chat-scrollbar-thumb: #d8d6d1;
+    --chat-scrollbar-hover: #c3c0b8;
+    --chat-heading: #1f1f1f;
+    --chat-strong: #1f1f1f;
+    --chat-em: #4b4b47;
+    --chat-del: #74716a;
+    --chat-blockquote-bg: #f1f1ef;
+    --chat-blockquote-text: #4b4b47;
+    --chat-table-header-bg: #f1f1ef;
+    --chat-table-alt-bg: #f6f6f4;
+    --chat-input-bg: #fafaf9;
     --chat-btn-text: #ffffff;
-    --chat-ai-text: #3f5f84;
-    --chat-user-text: #2e3440;
-    --chat-hover-bg: #dde3ec;
-    --chat-bg-secondary: #e5e9f0;
-    --chat-diff-add-bg: rgba(95, 122, 96, 0.14);
-    --chat-diff-add-text: #4f6b53;
-    --chat-diff-del-bg: rgba(163, 75, 92, 0.14);
-    --chat-diff-del-text: #8f3f4f;
+    --chat-ai-text: #0057d9;
+    --chat-user-text: #242424;
+    --chat-hover-bg: #ececea;
+    --chat-bg-secondary: #f4f4f2;
+    --chat-diff-add-bg: rgba(26, 127, 55, 0.12);
+    --chat-diff-add-text: #1a7f37;
+    --chat-diff-del-bg: rgba(207, 34, 46, 0.12);
+    --chat-diff-del-text: #cf222e;
   }
 
   /* 聊天框样式 */
@@ -2521,7 +2521,7 @@ export const chatStyles = css`
   }
 
   .chat-line-assistant {
-    color: var(--chat-ai-text);
+    color: var(--chat-text);
     margin-top: 2px;
   }
 
@@ -2759,7 +2759,7 @@ export const chatStyles = css`
   }
 
   .chat-line-assistant {
-    color: var(--chat-ai-text);
+    color: var(--chat-text);
   }
 
   /* 加载状态 - 光标闪烁 */

--- a/test/core/client/ai-terminal.test.ts
+++ b/test/core/client/ai-terminal.test.ts
@@ -72,7 +72,7 @@ describe('client ai terminal output colors', () => {
     const input = '\x1b[48;2;41;41;41mUse /skills\x1b[0m';
     const output = renderTerminalOutput(input, 'light');
 
-    expect(output).toContain('\x1b[48;2;236;239;244m');
+    expect(output).toContain('\x1b[48;2;250;250;249m');
     expect(output).not.toContain('48;2;41;41;41');
     expect(renderTerminalOutput(input, 'dark')).toBe(input);
   });
@@ -83,14 +83,14 @@ describe('client ai terminal output colors', () => {
         '\x1b[40mblack bg\x1b[0m',
         'light',
       ),
-    ).toContain('\x1b[48;2;236;239;244m');
+    ).toContain('\x1b[48;2;250;250;249m');
 
     expect(
       renderTerminalOutput(
         '\x1b[48;5;236mindexed bg\x1b[0m',
         'light',
       ),
-    ).toContain('\x1b[48;2;236;239;244m');
+    ).toContain('\x1b[48;2;250;250;249m');
   });
 
   it('should remap low-contrast light foregrounds in light terminal output', () => {
@@ -99,14 +99,14 @@ describe('client ai terminal output colors', () => {
         '\x1b[38;2;245;245;245mwhite text\x1b[0m',
         'light',
       ),
-    ).toContain('\x1b[38;2;46;52;64m');
+    ).toContain('\x1b[38;2;36;36;36m');
 
     expect(
       renderTerminalOutput(
         '\x1b[37mwhite ansi text\x1b[0m',
         'light',
       ),
-    ).toContain('\x1b[38;2;46;52;64m');
+    ).toContain('\x1b[38;2;36;36;36m');
   });
 
   it('should preserve opencode terminal output without theme normalization', () => {
@@ -126,7 +126,7 @@ describe('client ai terminal output colors', () => {
   it('should remap low-contrast light backgrounds and dark foregrounds in dark terminal output', () => {
     expect(
       renderTerminalOutput(
-        '\x1b[48;2;236;239;244mlight bg\x1b[0m',
+        '\x1b[48;2;250;250;249mlight bg\x1b[0m',
         'dark',
       ),
     ).toContain('\x1b[48;2;46;52;64m');
@@ -154,7 +154,7 @@ describe('client ai terminal output colors', () => {
     manager.write(input);
 
     expect(terminal.write).toHaveBeenLastCalledWith(
-      expect.stringContaining('\x1b[48;2;236;239;244m'),
+      expect.stringContaining('\x1b[48;2;250;250;249m'),
     );
 
     manager.setTheme('dark');
@@ -270,4 +270,3 @@ describe('client ai terminal output colors', () => {
   });
 
 });
-


### PR DESCRIPTION
## Summary
- refine the AI chat light theme with brighter neutral surfaces and #006aff-aligned accent colors
- keep assistant message text on the regular text color instead of coloring whole responses blue
- refresh light terminal palette and ANSI theme normalization test expectations

## Tests
- pnpm vitest run test/core/client/ai.test.ts test/core/client/ai-terminal.test.ts
- git diff --check