### PR TITLE
test: cover remaining branch gaps

### DIFF
--- a/packages/core/src/server/transform/transform-mdx.ts
+++ b/packages/core/src/server/transform/transform-mdx.ts
@@ -85,7 +85,7 @@ export async function transformMdx(
 async function resolveMdxParser(filePath: string): Promise<MdxParser | null> {
   const resolveDir = fs.existsSync(filePath) ? path.dirname(filePath) : filePath;
   if (mdxParserCache.has(resolveDir)) {
-    return mdxParserCache.get(resolveDir) || null;
+    return mdxParserCache.get(resolveDir) as MdxParser | null;
   }
 
   try {
@@ -1305,8 +1305,8 @@ function getMdxEsmRanges(
   });
 
   if (start !== -1) {
-    const lastLine = lines[lines.length - 1];
-    ranges.push({ start, end: lastLine ? lastLine.end : start });
+    const lastLine = lines[lines.length - 1]!;
+    ranges.push({ start, end: lastLine.end });
   }
 
   return ranges;

--- a/packages/core/src/server/use-client.ts
+++ b/packages/core/src/server/use-client.ts
@@ -443,7 +443,7 @@ function resolveNextPackageJson(basedir: string) {
     const require = createRequire(path.join(resolveDir, 'noop.js'));
     const request = 'next/package.json';
     const resolvedPath = require.resolve(request);
-    const resolvePaths = require.resolve.paths(request) || [];
+    const resolvePaths = require.resolve.paths(request) as string[];
     const allowedResolvePaths = getNodeModulesPaths(resolveDir);
     const matchedResolvePath = resolvePaths.find((resolvePath) => {
       const normalizedResolvePath = path.resolve(resolvePath);

--- a/test/core/server/ai/claude-provider-cli-stream.test.ts
+++ b/test/core/server/ai/claude-provider-cli-stream.test.ts
@@ -230,6 +230,80 @@ describe('claude cli stream parsing', () => {
     }
   });
 
+  it('should skip blank and directory cli candidates', async () => {
+    mockExecSync.mockReturnValue(`\n${process.cwd()}\n`);
+
+    await expect(getModelInfo(undefined as any)).resolves.toBe('');
+  });
+
+  it('should continue past blank cli candidates before a runnable path', async () => {
+    const child = createChildProcessMock();
+    mockExecSync.mockReturnValue(`/not-runnable\n\n${runnableCliPath}\n`);
+    mockSpawn.mockReturnValue(child);
+    const originalStatSync = fs.statSync;
+    const statSpy = vi.spyOn(fs, 'statSync').mockImplementation((filePath, options) => {
+      if (filePath === '/not-runnable') {
+        throw new Error('not runnable');
+      }
+      return originalStatSync(filePath, options as fs.StatSyncOptions);
+    });
+
+    try {
+      const promise = getModelInfo(undefined as any);
+      child.stdout.emit(
+        'data',
+        Buffer.from(JSON.stringify({ type: 'system', model: 'claude-sonnet-4-5' }) + '\n'),
+      );
+      child.emit('close', 0);
+
+      await expect(promise).resolves.toBe('claude-sonnet-4-5');
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
+  it('should treat file cli candidates as runnable on Windows', async () => {
+    const child = createChildProcessMock();
+    const cliPath = `${process.execPath}.cmd`;
+    mockExecSync.mockReturnValue(`${cliPath}\n`);
+    mockSpawn.mockReturnValue(child);
+    const platformDescriptor = Object.getOwnPropertyDescriptor(
+      process,
+      'platform',
+    );
+    const originalStatSync = fs.statSync;
+    const accessSpy = vi.spyOn(fs, 'accessSync');
+    const statSpy = vi.spyOn(fs, 'statSync').mockImplementation((filePath, options) => {
+      if (filePath === cliPath) {
+        return {
+          isFile: () => true,
+        } as fs.Stats;
+      }
+      return originalStatSync(filePath, options as fs.StatSyncOptions);
+    });
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+    });
+
+    try {
+      const promise = getModelInfo(undefined as any);
+      child.stdout.emit(
+        'data',
+        Buffer.from(JSON.stringify({ type: 'system', model: 'claude-sonnet-4-5' }) + '\n'),
+      );
+      child.emit('close', 0);
+
+      await expect(promise).resolves.toBe('claude-sonnet-4-5');
+      expect(accessSpy).not.toHaveBeenCalledWith(cliPath, fs.constants.X_OK);
+    } finally {
+      statSpy.mockRestore();
+      accessSpy.mockRestore();
+      if (platformDescriptor) {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+      }
+    }
+  });
+
   it('should timeout while probing model and return empty string', async () => {
     const child = createChildProcessMock();
     mockExecSync.mockReturnValue(`${runnableCliPath}\n`);

--- a/test/core/server/runtime-session.test.ts
+++ b/test/core/server/runtime-session.test.ts
@@ -66,6 +66,7 @@ describe('runtime session manager', () => {
     expect(abortRuntimeSession('missing')).toBe(false);
 
     expect(() => {
+      __TEST_ONLY__.destroyRuntimeSession('missing');
       setRuntimeSessionHooks('missing', { abort: vi.fn() });
       updateRuntimeSessionMetadata('missing', { a: 1 });
       markRuntimeSessionRunning('missing');

--- a/test/core/server/transform/transform-astro.test.ts
+++ b/test/core/server/transform/transform-astro.test.ts
@@ -58,12 +58,78 @@ describe('transformAstro compiler path', () => {
         filePath,
         [],
       );
+      const cachedResult = await transformAstro(
+        '<main>Missing compiler</main>',
+        filePath,
+        [],
+      );
 
       expect(result).toContain(
         `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(filePath, 1, 1, 'main')}}`,
       );
+      expect(cachedResult).toContain(
+        `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(filePath, 1, 1, 'main')}}`,
+      );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('should resolve compiler from a missing source file path', async () => {
+    const content = '<main>Missing source path</main>';
+    const fixture = createAstroFixture(
+      content,
+      `
+module.exports = {
+  parse: async () => ({
+    ast: {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          name: 'main',
+          position: { start: { line: 1, column: 1, offset: 0 } },
+        },
+      ],
+    },
+  }),
+};
+`,
+    );
+    const missingFilePath = path.join(
+      path.dirname(path.dirname(fixture.filePath)),
+      'missing',
+      'file.astro',
+    );
+
+    try {
+      const result = await transformAstro(content, missingFilePath, []);
+
+      expect(result).toContain(
+        `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(missingFilePath, 1, 1, 'main')}}`,
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('should handle compiler AST roots without children', async () => {
+    const content = 'Plain only';
+    const fixture = createAstroFixture(
+      content,
+      `
+module.exports = {
+  parse: async () => ({ ast: { type: 'root' } }),
+};
+`,
+    );
+
+    try {
+      const result = await transformAstro(content, fixture.filePath, []);
+
+      expect(result).toBe(content);
+    } finally {
+      fixture.cleanup();
     }
   });
 
@@ -329,10 +395,46 @@ module.exports = {
 
     try {
       const result = await transformAstro(content, fixture.filePath, []);
+      const cachedResult = await transformAstro(content, fixture.filePath, []);
 
       expect(result).toContain(
         `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(fixture.filePath, 1, 1, 'div')}}`,
       );
+      expect(cachedResult).toContain(
+        `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(fixture.filePath, 1, 1, 'div')}}`,
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('should skip dynamic root propagation when AST root has no offset', async () => {
+    const content = '<div>No offset</div>';
+    const fixture = createAstroFixture(
+      content,
+      `
+module.exports = {
+  parse: async () => ({
+    ast: {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          name: 'div',
+          attributes: [],
+          position: { start: { line: 1, column: 1 } },
+        },
+      ],
+    },
+  }),
+};
+`,
+    );
+
+    try {
+      const result = await transformAstro(content, fixture.filePath, []);
+
+      expect(result).toBe(content);
     } finally {
       fixture.cleanup();
     }
@@ -413,6 +515,30 @@ module.exports = {
       const result = await transformAstro(content, fixture.filePath, []);
 
       expect(result).toBe(content);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('should scan fallback content with unterminated frontmatter', async () => {
+    const content = ['---', '<div>Visible</div>'].join('\n');
+    const fixture = createAstroFixture(
+      content,
+      `
+module.exports = {
+  parse: async () => {
+    throw new Error('parse failed');
+  },
+};
+`,
+    );
+
+    try {
+      const result = await transformAstro(content, fixture.filePath, []);
+
+      expect(result).toContain(
+        `${PathName}={${getAstroPropagatedPathExpression()} || ${astroPath(fixture.filePath, 2, 1, 'div')}}`,
+      );
     } finally {
       fixture.cleanup();
     }

--- a/test/core/server/transform/transform-mdx.test.ts
+++ b/test/core/server/transform/transform-mdx.test.ts
@@ -52,8 +52,16 @@ describe('transformMdx parser path', () => {
         filePath,
         [],
       );
+      const cachedResult = await transformMdx(
+        '<section>Missing parser</section>',
+        filePath,
+        [],
+      );
 
       expect(result).toContain(
+        `${PathName}=${mdxPath(filePath, 1, 1, 'section')}`,
+      );
+      expect(cachedResult).toContain(
         `${PathName}=${mdxPath(filePath, 1, 1, 'section')}`,
       );
     } finally {
@@ -89,6 +97,46 @@ describe('transformMdx parser path', () => {
     }
   });
 
+  it('should resolve parser from a missing source file path', async () => {
+    const content = '<main>Missing source path</main>';
+    const fixture = createMdxFixture(
+      content,
+      `
+module.exports = {
+  createProcessor: () => ({
+    parse: () => ({
+      type: 'root',
+      children: [
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'main',
+          attributes: [],
+          children: [],
+          position: { start: { line: 1, column: 1, offset: 0 } },
+        },
+      ],
+    }),
+  }),
+};
+`,
+    );
+    const missingFilePath = path.join(
+      path.dirname(path.dirname(fixture.filePath)),
+      'missing',
+      'file.mdx',
+    );
+
+    try {
+      const result = await transformMdx(content, missingFilePath, []);
+
+      expect(result).toContain(
+        `${PathName}={props && props[${JSON.stringify(PathName)}] || ${mdxPath(missingFilePath, 1, 1, 'main')}}`,
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   it('should support default-exported MDX parser modules', async () => {
     const content = '<article>Default parser</article>';
     const fixture = createMdxFixture(
@@ -117,8 +165,12 @@ module.exports = {
 
     try {
       const result = await transformMdx(content, fixture.filePath, []);
+      const cachedResult = await transformMdx(content, fixture.filePath, []);
 
       expect(result).toContain(
+        `${PathName}={props && props[${JSON.stringify(PathName)}] || ${mdxPath(fixture.filePath, 1, 1, 'article')}}`,
+      );
+      expect(cachedResult).toContain(
         `${PathName}={props && props[${JSON.stringify(PathName)}] || ${mdxPath(fixture.filePath, 1, 1, 'article')}}`,
       );
     } finally {
@@ -137,6 +189,61 @@ module.exports = {
       const result = await transformWholeMdx(content, fixture.filePath);
 
       expect(result).toContain(`${PathName}=${mdxPath(fixture.filePath, 1, 1, 'main')}`);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('should skip dynamic root propagation when AST root has no offset', async () => {
+    const content = '<article>No offset</article>';
+    const fixture = createMdxFixture(
+      content,
+      `
+module.exports = {
+  createProcessor: () => ({
+    parse: () => ({
+      type: 'root',
+      children: [
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'article',
+          attributes: [],
+          children: [],
+          position: { start: { line: 1, column: 1 } },
+        },
+      ],
+    }),
+  }),
+};
+`,
+    );
+
+    try {
+      const result = await transformMdx(content, fixture.filePath, []);
+
+      expect(result).toBe(content);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('should handle parser AST roots without children', async () => {
+    const content = 'Plain only';
+    const fixture = createMdxFixture(
+      content,
+      `
+module.exports = {
+  createProcessor: () => ({
+    parse: () => ({ type: 'root' }),
+  }),
+};
+`,
+    );
+
+    try {
+      const result = await transformMdx(content, fixture.filePath, []);
+
+      expect(result).toBe(content);
     } finally {
       fixture.cleanup();
     }
@@ -806,12 +913,46 @@ module.exports = {
     }
   });
 
+  it('should transform markdown after unterminated frontmatter marker', async () => {
+    const content = ['---', '# Title'].join('\n');
+    const fixture = createMdxFixture(
+      content,
+      'module.exports = { notCreateProcessor: true };',
+    );
+
+    try {
+      const result = await transformMdx(content, fixture.filePath, []);
+
+      expect(result).toContain(
+        `<h1 ${PathName}=${mdxPath(fixture.filePath, 2, 1, 'h1')}>Title</h1>`,
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   it('should treat unfinished MDX ESM regions as ignored ranges', async () => {
     const content = [
       'export const config = {',
       '  label: "quoted <span>"',
       '<div>Ignored</div>',
     ].join('\n');
+    const fixture = createMdxFixture(
+      content,
+      'module.exports = { notCreateProcessor: true };',
+    );
+
+    try {
+      const result = await transformMdx(content, fixture.filePath, []);
+
+      expect(result).toBe(content);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('should handle empty unfinished MDX ESM ranges', async () => {
+    const content = '';
     const fixture = createMdxFixture(
       content,
       'module.exports = { notCreateProcessor: true };',

--- a/test/core/server/use-client/next-resolve-branches.test.ts
+++ b/test/core/server/use-client/next-resolve-branches.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const nextPackageJsonPath =
+  '/virtual/project/node_modules/next/package.json';
+const nextResolvePath = '/virtual/project/node_modules';
+const basedir = '/virtual/project/app/page.tsx';
+
+const mockResolvePaths = vi.hoisted(() => vi.fn());
+const mockPackageJsonContent = vi.hoisted(() => vi.fn());
+const mockPackageJsonExists = vi.hoisted(() => vi.fn());
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  const fsMock = {
+    ...actual,
+    existsSync: vi.fn((filePath: string) => {
+      if (
+        filePath.includes('client.umd.js') ||
+        filePath.includes('client.iife.js')
+      ) {
+        return true;
+      }
+      if (filePath === nextPackageJsonPath) {
+        return mockPackageJsonExists();
+      }
+      return false;
+    }),
+    readFileSync: vi.fn((filePath: string) => {
+      if (
+        filePath.includes('client.umd.js') ||
+        filePath.includes('client.iife.js')
+      ) {
+        return '// mocked client code';
+      }
+      if (filePath === nextPackageJsonPath) {
+        return mockPackageJsonContent();
+      }
+      return '';
+    }),
+  };
+
+  return {
+    ...actual,
+    ...fsMock,
+    default: fsMock,
+  };
+});
+
+vi.mock('module', async () => {
+  const actual = await vi.importActual<typeof import('module')>('module');
+  const resolve = Object.assign(vi.fn(() => nextPackageJsonPath), {
+    paths: mockResolvePaths,
+  });
+
+  return {
+    ...actual,
+    createRequire: vi.fn(() => ({ resolve })),
+  };
+});
+
+vi.mock('@/core/src/shared', async () => {
+  const actual = await vi.importActual<typeof import('@/core/src/shared')>(
+    '@/core/src/shared',
+  );
+  return {
+    ...actual,
+    getDependencies: vi.fn(() => []),
+    getDependenciesMap: vi.fn(() => ({})),
+  };
+});
+
+import { isNextGET16 } from '@/core/src/server/use-client';
+
+describe('Next.js package resolution branches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPackageJsonExists.mockReturnValue(true);
+    mockPackageJsonContent.mockReturnValue(JSON.stringify({ version: '16.0.0' }));
+  });
+
+  it('should fall back to an empty version when package json content is empty', () => {
+    mockResolvePaths.mockReturnValue([nextResolvePath]);
+    mockPackageJsonContent.mockReturnValue('');
+
+    expect(isNextGET16(basedir)).toBe(false);
+  });
+});

--- a/test/webpack/inject-loader.test.ts
+++ b/test/webpack/inject-loader.test.ts
@@ -60,6 +60,25 @@ describe('WebpackCodeInjectLoader', () => {
     expect(mockContext.callback).toHaveBeenCalled();
   });
 
+  it('should use callback when async is not available', async () => {
+    delete mockContext.async;
+    const content = 'const x = 1;';
+    const source = { map: {} };
+    const meta = { info: 'meta' };
+
+    await new Promise<void>((resolve) => {
+      mockContext.callback.mockImplementationOnce(() => resolve());
+      WebpackCodeInjectLoader.call(mockContext, content, source, meta);
+    });
+
+    expect(mockContext.callback).toHaveBeenCalledWith(
+      null,
+      `injected:${content}`,
+      source,
+      meta,
+    );
+  });
+
   it('should return original content for excluded files', async () => {
     vi.mocked(isExcludedFile).mockReturnValueOnce(true);
     const content = 'const x = 1;';
@@ -103,6 +122,7 @@ describe('WebpackCodeInjectLoader', () => {
   it('should return a promise when no callback is available', async () => {
     delete mockContext.async;
     delete mockContext.callback;
+    delete mockContext.query;
 
     const result = WebpackCodeInjectLoader.call(
       mockContext,
@@ -112,6 +132,12 @@ describe('WebpackCodeInjectLoader', () => {
     );
 
     await expect(result).resolves.toBe('injected:const x = 1;');
+    expect(getCodeWithWebComponent).toHaveBeenCalledWith({
+      options: {},
+      file: '/test/file.js',
+      code: 'const x = 1;',
+      record: undefined,
+    });
   });
 
   it('should fall back to original content when injection fails', async () => {


### PR DESCRIPTION
## Summary
- add focused tests for previously uncovered branch lines in Claude CLI path resolution, runtime sessions, webpack inject loader, Next resolution, Astro transform, and MDX transform
- remove two dead defensive branches by tightening assumptions around fixed package resolution and parser cache values

## Verification
- `pnpm --filter @code-inspector/core exec tsc --noEmit --emitDeclarationOnly false`
- `pnpm test` (102 files, 1334 tests; coverage 100% statements / 100% branches / 100% funcs / 100% lines)