### PR TITLE
fix(core): align inspector header content

### DIFF
--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -3851,6 +3851,15 @@ export class CodeInspectorComponent extends LitElement {
         color: #c25e00;
         font-weight: bold;
       }
+      .inspector-info-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+      }
+      .element-tag-info {
+        min-width: 0;
+      }
       .element-dimensions {
         flex-shrink: 0;
         color: #222;


### PR DESCRIPTION
## Summary

- keep the element selector and dimensions on the same row
- align them to opposite sides of the inspector header
- prevent the dimensions from shrinking when the selector is long

## Verification

- `pnpm --filter @code-inspector/core run build:client`