### PR TITLE
fix: prevent Windows postinstall hang

### DIFF
--- a/packages/core/scripts/verify-terminal-runtime.js
+++ b/packages/core/scripts/verify-terminal-runtime.js
@@ -193,11 +193,6 @@ async function runTerminalRuntimeCheck(options) {
   // which prevents the probe timeout from starting and stalls package installs.
   // See https://github.com/microsoft/node-pty/issues/763.
   if (platform === 'win32') {
-    logMessage(
-      logger,
-      'log',
-      'Skipping terminal runtime verification on Windows because spawning ConPTY during package installation can block the installer.',
-    );
     return {
       ok: true,
       skipped: true,

--- a/packages/core/scripts/verify-terminal-runtime.js
+++ b/packages/core/scripts/verify-terminal-runtime.js
@@ -188,6 +188,25 @@ async function runTerminalRuntimeCheck(options) {
   const platform = settings.platform || process.platform;
   const arch = settings.arch || process.arch;
   const resolveFromDir = settings.resolveFromDir || __dirname;
+
+  // node-pty can block synchronously while connecting ConPTY pipes on Windows,
+  // which prevents the probe timeout from starting and stalls package installs.
+  // See https://github.com/microsoft/node-pty/issues/763.
+  if (platform === 'win32') {
+    logMessage(
+      logger,
+      'log',
+      'Skipping terminal runtime verification on Windows because spawning ConPTY during package installation can block the installer.',
+    );
+    return {
+      ok: true,
+      skipped: true,
+      fixedPaths: [],
+      helperPaths: [],
+      reason: 'Terminal runtime verification is deferred on Windows.',
+    };
+  }
+
   const nodePtyRoot = Object.prototype.hasOwnProperty.call(
     settings,
     'nodePtyRoot',

--- a/test/core/scripts/verify-terminal-runtime.test.ts
+++ b/test/core/scripts/verify-terminal-runtime.test.ts
@@ -142,6 +142,33 @@ describe('verify terminal runtime script', () => {
     expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 
+  it('should skip the PTY probe on Windows during installation', async () => {
+    const logger = {
+      log: vi.fn(),
+      warn: vi.fn(),
+    };
+    const spawn = vi.fn(() => {
+      throw new Error('Windows PTY probe must not run during installation');
+    });
+
+    const result = await verifyTerminalRuntime.runTerminalRuntimeCheck({
+      logger,
+      nodePtyRoot: 'C:\\node_modules\\node-pty',
+      nodePty: { spawn },
+      platform: 'win32',
+      arch: 'x64',
+      cwd: process.cwd(),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe(
+      'Terminal runtime verification is deferred on Windows.',
+    );
+    expect(spawn).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it('should skip verification when node-pty is not installed', async () => {
     const logger = {
       log: vi.fn(),


### PR DESCRIPTION
## Summary

- skip the install-time PTY runtime probe on Windows before loading node-pty
- keep the Unix spawn-helper permission repair and runtime probe unchanged
- add a regression test proving the Windows postinstall path never calls nodePty.spawn

## Root cause

node-pty 1.1.0 can synchronously block the Node.js event loop in ConnectNamedPipe on Windows when the ConPTY output worker has not connected yet. The current 2-second watchdog is created only after nodePty.spawn returns, so it cannot interrupt this synchronous block and npm waits forever for the postinstall process.

Upstream evidence:
- https://github.com/microsoft/node-pty/issues/763
- https://github.com/microsoft/node-pty/commit/ca0ccf876ff5087b2df1b3c1661cf05248cb8c91

The Windows postinstall branch has no helper permission repair to perform and does not persist its probe result, so deferring the verification to actual terminal usage removes the installation risk without disabling terminal support.

## Verification

- regression test failed before the fix because the Windows path called spawn
- synchronous-hang injection now exits the Windows postinstall path in 22ms
- 26 related tests pass across terminal runtime verification, AI terminal helpers, and runtime sessions
- git diff --check passes

The repository CI currently runs only on Ubuntu, so the regression test uses the Windows platform seam and a spawn function that must never be invoked.