### PR TITLE
fix: make node-pty an optionalDependency

### DIFF
--- a/docs/en/guide/feature/ai.md
+++ b/docs/en/guide/feature/ai.md
@@ -151,6 +151,10 @@ codeInspectorPlugin({
 
 Terminal mode opens a native Codex CLI terminal in the AI panel. It requires the current runtime to load `node-pty` and `ws`; if terminal support is unavailable, model info is downgraded and displayed as CLI mode.
 
+:::tip node-pty is optional
+`node-pty` is an optional dependency (native addon). Package managers skip it when prebuilds/build tools are missing (`node-gyp`, python, make, g++), so installing `code-inspector-plugin` still succeeds. Locate and AI CLI/SDK modes keep working; only terminal mode is disabled until `node-pty` installs successfully.
+:::
+
 ```js
 codeInspectorPlugin({
   behavior: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,9 +57,11 @@
     "chalk": "^4.1.1",
     "dotenv": "^16.1.4",
     "launch-ide": "1.4.5",
-    "node-pty": "^1.1.0",
     "portfinder": "^1.0.28",
     "ws": "^8.18.0"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.3",

--- a/packages/core/scripts/verify-terminal-runtime.js
+++ b/packages/core/scripts/verify-terminal-runtime.js
@@ -212,8 +212,8 @@ async function runTerminalRuntimeCheck(options) {
   if (!nodePtyRoot) {
     logMessage(
       logger,
-      'log',
-      'Skipping terminal runtime verification because node-pty is not installed.',
+      'warn',
+      'node-pty is not available; AI terminal mode will be disabled. Locate and AI CLI/SDK modes still work. Install build tools (python/make/g++) or reinstall node-pty to enable terminal mode.',
     );
     return {
       ok: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 20.14.11
       '@vitest/coverage-v8':
         specifier: 2.1.4
-        version: 2.1.4(vitest@2.1.4(@types/node@20.14.11)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@6.0.4))(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))
+        version: 2.1.4(supports-color@6.1.0)(vitest@2.1.4(@types/node@20.14.11)(jsdom@25.0.1(bufferutil@4.0.8)(supports-color@6.1.0)(utf-8-validate@6.0.4))(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(supports-color@6.1.0)(terser@5.30.4))
       fs-extra:
         specifier: ^10.0.0
         version: 10.0.0
@@ -25,7 +25,7 @@ importers:
         version: 8.0.3
       jsdom:
         specifier: ^25.0.1
-        version: 25.0.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+        version: 25.0.1(bufferutil@4.0.8)(supports-color@6.1.0)(utf-8-validate@6.0.4)
       launch-ide:
         specifier: 1.4.5
         version: 1.4.5
@@ -37,7 +37,7 @@ importers:
         version: 1.2.2
       vitest:
         specifier: ^2.1.4
-        version: 2.1.4(@types/node@20.14.11)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@6.0.4))(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)
+        version: 2.1.4(@types/node@20.14.11)(jsdom@25.0.1(bufferutil@4.0.8)(supports-color@6.1.0)(utf-8-validate@6.0.4))(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(supports-color@6.1.0)(terser@5.30.4)
       zip-a-folder:
         specifier: ^3.1.7
         version: 3.1.7
@@ -96,7 +96,7 @@ importers:
         version: 1.0.2
       '@farmfe/core':
         specifier: ^1.2.4
-        version: 1.2.8(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+        version: 1.2.8(bufferutil@4.0.8)(supports-color@6.1.0)(utf-8-validate@6.0.4)
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
         version: 5.0.5(vite@7.3.5(@types/node@24.10.0)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)(yaml@2.9.0))(vue@3.4.30(typescript@5.9.3))
@@ -111,7 +111,7 @@ importers:
     dependencies:
       umi:
         specifier: ^4.4.12
-        version: 4.4.12(@babel/core@7.24.7)(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(@types/node@24.10.0)(@types/react@18.3.3)(@types/webpack@4.41.33)(@volar/vue-typescript@1.2.0)(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(lightningcss@1.30.2)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.4)(sass-embedded@1.79.4)(sass@1.54.7)(sockjs-client@1.6.1)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(type-fest@3.13.1)(typescript@5.8.2)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))
+        version: 4.4.12(@babel/core@7.24.7)(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(@types/node@24.10.0)(@types/react@18.3.3)(@types/webpack@4.41.33)(@volar/vue-typescript@1.2.0)(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(lightningcss@1.30.2)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@18.3.1)(rollup@3.29.4)(sass-embedded@1.79.4)(sass@1.54.7)(sockjs-client@1.6.1)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(supports-color@6.1.0)(terser@5.30.4)(type-fest@3.13.1)(typescript@5.8.2)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))
     devDependencies:
       '@types/react':
         specifier: ^18.0.33
@@ -130,7 +130,7 @@ importers:
     dependencies:
       next:
         specifier: 15.1.9
-        version: 15.1.9(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.54.7)
+        version: 15.1.9(@babel/core@7.24.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.54.7)
       react:
         specifier: ^19.0.1
         version: 19.2.1
@@ -155,10 +155,10 @@ importers:
         version: link:../../packages/code-inspector-plugin
       eslint:
         specifier: ^9
-        version: 9.18.0(jiti@2.6.1)
+        version: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       eslint-config-next:
         specifier: 15.1.6
-        version: 15.1.6(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)
+        version: 15.1.6(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0)(typescript@5.5.3)
       postcss:
         specifier: ^8
         version: 8.4.41
@@ -195,10 +195,10 @@ importers:
         version: link:../../packages/code-inspector-plugin
       eslint:
         specifier: ^8
-        version: 8.28.0
+        version: 8.28.0(supports-color@6.1.0)
       eslint-config-next:
         specifier: 14.2.4
-        version: 14.2.4(eslint@8.28.0)(typescript@5.4.5)
+        version: 14.2.4(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0)(typescript@5.4.5)
       postcss:
         specifier: ^8
         version: 8.4.38
@@ -213,7 +213,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ^3.12.2
-        version: 3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@24.10.0)(bufferutil@4.0.8)(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.4.1)(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
+        version: 3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@24.10.0)(bluebird@3.7.2)(bufferutil@4.0.8)(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.4.1)(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(supports-color@6.1.0)(terser@5.30.4)(typescript@5.9.3)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
       vue:
         specifier: ^3.4.29
         version: 3.4.30(typescript@5.9.3)
@@ -310,7 +310,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.1
-        version: 16.0.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.1.16
         version: 4.1.16
@@ -325,7 +325,7 @@ importers:
         version: 0.5.5(prettier@3.8.3)(typescript@5.3.3)
       astro:
         specifier: ^4.4.1
-        version: 4.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)(typescript@5.3.3)
+        version: 4.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(supports-color@6.1.0)(terser@5.30.4)(typescript@5.3.3)
       code-inspector-plugin:
         specifier: workspace:*
         version: link:../../packages/code-inspector-plugin
@@ -393,7 +393,7 @@ importers:
         version: 5.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       axios:
         specifier: ^1.2.0
-        version: 1.2.0
+        version: 1.2.0(debug@4.3.4)
       classnames:
         specifier: ^2.3.2
         version: 2.3.2
@@ -448,7 +448,7 @@ importers:
         version: 5.1.26
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.44.0
-        version: 5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(typescript@4.9.5)
+        version: 5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5)
       '@typescript-eslint/parser':
         specifier: ^5.44.0
         version: 5.44.0(eslint@8.28.0)(typescript@4.9.5)
@@ -463,7 +463,7 @@ importers:
         version: 8.28.0
       eslint-config-alloy:
         specifier: ^4.7.0
-        version: 4.7.0(@babel/eslint-parser@7.23.3(@babel/core@7.21.3)(eslint@8.28.0))(@babel/preset-react@7.22.5(@babel/core@7.21.3))(@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(typescript@4.9.5))(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint-plugin-react@7.32.2(eslint@8.28.0))(eslint@8.28.0)(typescript@4.9.5)(vue-eslint-parser@9.0.3(eslint@8.28.0))
+        version: 4.7.0(@babel/eslint-parser@7.23.3(@babel/core@7.24.7)(eslint@8.28.0))(@babel/preset-react@7.22.5(@babel/core@7.24.7))(@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5))(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint-plugin-react@7.32.2(eslint@8.28.0))(eslint@8.28.0)(typescript@4.9.5)(vue-eslint-parser@9.0.3(eslint@8.28.0))
       eslint-plugin-react:
         specifier: ^7.31.11
         version: 7.32.2(eslint@8.28.0)
@@ -506,7 +506,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.1
-        version: 3.1.1(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))
+        version: 3.1.1(supports-color@6.1.0)(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))
       '@tsconfig/svelte':
         specifier: ^5.0.4
         version: 5.0.4
@@ -536,7 +536,7 @@ importers:
         version: 1.1.0(rollup@4.61.1)(vite@4.3.9(@types/node@18.14.1)(less@4.2.0)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.4.21))(terser@5.15.0))(vue@2.7.10)
       axios:
         specifier: ^0.27.2
-        version: 0.27.2
+        version: 0.27.2(debug@4.3.4)
       element-ui:
         specifier: ^2.15.9
         version: 2.15.9(vue@2.7.10)
@@ -555,7 +555,7 @@ importers:
         version: 18.14.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.37.0
-        version: 5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(typescript@4.9.5)
+        version: 5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5)
       '@typescript-eslint/parser':
         specifier: ^5.37.0
         version: 5.44.0(eslint@8.28.0)(typescript@4.9.5)
@@ -609,7 +609,7 @@ importers:
         version: 4.3.9(@types/node@18.14.1)(less@4.2.0)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.4.21))(terser@5.15.0)
       vite-plugin-mock:
         specifier: ^2.9.6
-        version: 2.9.6(mockjs@1.1.0)(rollup@4.61.1)(vite@4.3.9(@types/node@18.14.1)(less@4.2.0)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.4.21))(terser@5.15.0))
+        version: 2.9.6(mockjs@1.1.0)(rollup@4.61.1)(supports-color@6.1.0)(vite@4.3.9(@types/node@18.14.1)(less@4.2.0)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.4.21))(terser@5.15.0))
       vue-eslint-parser:
         specifier: ^9.0.3
         version: 9.0.3(eslint@8.28.0)
@@ -685,7 +685,7 @@ importers:
         version: 0.5.3(@types/webpack@4.41.33)(react-refresh@0.11.0)(sockjs-client@1.6.1)(type-fest@2.19.0)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.64.4(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.64.4(@swc/core@1.11.13(@swc/helpers@0.5.15)))
       '@svgr/webpack':
         specifier: ^5.5.0
-        version: 5.5.0
+        version: 5.5.0(supports-color@6.1.0)
       '@testing-library/jest-dom':
         specifier: ^5.14.1
         version: 5.14.1
@@ -718,7 +718,7 @@ importers:
         version: 0.3.8(@babel/core@7.21.3)
       babel-preset-react-app:
         specifier: ^10.0.1
-        version: 10.0.1
+        version: 10.0.1(supports-color@6.1.0)
       bfj:
         specifier: ^7.0.2
         version: 7.0.2
@@ -751,7 +751,7 @@ importers:
         version: 8.28.0
       eslint-config-react-app:
         specifier: ^7.0.1
-        version: 7.0.1(@babel/plugin-syntax-flow@7.22.5(@babel/core@7.21.3))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.21.3))(eslint@8.28.0)(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@16.18.12)(typescript@4.9.5))(utf-8-validate@5.0.10))(typescript@4.9.5)
+        version: 7.0.1(@babel/plugin-syntax-flow@7.22.5(@babel/core@7.21.3))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.21.3))(eslint@8.28.0)(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@16.18.12)(typescript@4.9.5))(utf-8-validate@5.0.10))(supports-color@6.1.0)(typescript@4.9.5)
       eslint-webpack-plugin:
         specifier: ^3.1.1
         version: 3.1.1(eslint@8.28.0)(webpack@5.64.4(@swc/core@1.11.13(@swc/helpers@0.5.15)))
@@ -805,7 +805,7 @@ importers:
         version: 3.0.0
       react-dev-utils:
         specifier: ^12.0.1
-        version: 12.0.1(eslint@8.28.0)(typescript@4.9.5)(vue-template-compiler@2.7.14)(webpack@5.64.4(@swc/core@1.11.13(@swc/helpers@0.5.15)))
+        version: 12.0.1(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5)(vue-template-compiler@2.7.14)(webpack@5.64.4(@swc/core@1.11.13(@swc/helpers@0.5.15)))
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
@@ -1022,9 +1022,6 @@ importers:
       launch-ide:
         specifier: 1.4.5
         version: 1.4.5
-      node-pty:
-        specifier: ^1.1.0
-        version: 1.1.0
       portfinder:
         specifier: ^1.0.28
         version: 1.0.32(supports-color@6.1.0)
@@ -1083,6 +1080,10 @@ importers:
       volar-service-pug:
         specifier: ^0.0.63
         version: 0.0.63
+    optionalDependencies:
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
 
   packages/esbuild:
     dependencies:
@@ -2835,15 +2836,15 @@ packages:
 
   '@esbuild-kit/cjs-loader@2.4.4':
     resolution: {integrity: sha512-NfsJX4PdzhwSkfJukczyUiZGc7zNNWZcEAyqeISpDnn0PTfzMJR1aR8xAIPskBejIxBJbIgCCMzbaYa9SXepIg==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.19.10':
     resolution: {integrity: sha512-Q+mk96KJ+FZ30h9fsJl+67IjNJm3x2eX+GBWGmocAKgzp27cowCOOqSdscX80s0SpdFXZnIv/+1xD1EctFx96Q==}
@@ -3923,12 +3924,14 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@farmfe/core-linux-x64-musl@1.2.8':
     resolution: {integrity: sha512-+ncq7JLmM/zSeTQkZhBQO15c/2Svv/75t20G3bqD9bHcUWYwb5sUDs1Nxt69aJqp1zY29Q8VT9DREAYkOSJdew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@farmfe/core-win32-arm64-msvc@1.2.8':
     resolution: {integrity: sha512-5qLKljphERE0dJLehL9s4UeIBSCYfBzdzuCZ249fgZoJQ62p0/VcnHUf6uT0ayQCX1hU6LD43S2Mha2s5ZVyHA==}
@@ -4113,144 +4116,170 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.3':
     resolution: {integrity: sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.3':
     resolution: {integrity: sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.3':
     resolution: {integrity: sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.3':
     resolution: {integrity: sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.3':
     resolution: {integrity: sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.3':
     resolution: {integrity: sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.3':
     resolution: {integrity: sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.4':
     resolution: {integrity: sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.4':
     resolution: {integrity: sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.4':
     resolution: {integrity: sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.4':
     resolution: {integrity: sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.4':
     resolution: {integrity: sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.4':
     resolution: {integrity: sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.4':
     resolution: {integrity: sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -4579,42 +4608,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.0.4':
     resolution: {integrity: sha512-4b1KYG+sriufhFrpUS9uNOEYYJqSfcbnwGx6uGX7JjrH8tELG90cOpCawz5THNIwlS3DhLgnCOcn0+4p6z26QA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.0.4':
     resolution: {integrity: sha512-iaf3vMRgr23oe1PUaKpxaH3DS0IMN0+N9iEiWVwYPm/U15vZFYdqVegGfN2PzrZLUl5lc8ZxbmEKDfuqslhAMA==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.0.4':
     resolution: {integrity: sha512-UXoREY6Yw6rHrGuTwQgBxpfjK34t6mTjibE9/cXbefL9AuUCJ9gEgwNKZiONuR5QGswChqo9cnthjdKkYyAdDg==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.0.4':
     resolution: {integrity: sha512-eFbgYCRPmsqbYPAlLYU5hYTNbogmIDUvknilehHsFhCH1+0/kN87lP+XaLT0Yeq4V/rpwChSd9vlz4muzFArtw==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.0.4':
     resolution: {integrity: sha512-4T3E6uTCwWT6IPnwuPcWVz3oHxvEp/qbrCxZhsgzwTUBEwu78EGNXGdHfKJQt3soth89MLqZJw+Zzvnhrsg1mQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.0.4':
     resolution: {integrity: sha512-NtbBkAeyBPLvCBkWtwkKXkNSn677eaT0cX3tygq+2qVv71TmHgX4gkX6o9BXjlPzdgPGwrUudavCYPT9tzkEqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-win32-arm64-msvc@1.0.4':
     resolution: {integrity: sha512-vubOe3i+YtSJGEk/++73y+TIxbuVHi+W8ZzrRm2eETCjCRwNlgbfToQZ85dSA+4iBB/NJRGNp+O4hfdbbttZWA==}
@@ -4720,72 +4756,84 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-gnu@15.1.9':
     resolution: {integrity: sha512-77rYykF6UtaXvxh9YyRIKoaYPI6/YX6cy8j1DL5/1XkjbfOwFDfTEhH7YGPqG/ePl+emBcbDYC2elgEqY2e+ag==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-gnu@16.0.7':
     resolution: {integrity: sha512-mloD5WcPIeIeeZqAIP5c2kdaTa6StwP4/2EGy1mUw8HiexSHGK/jcM7lFuS3u3i2zn+xH9+wXJs6njO7VrAqww==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@14.2.4':
     resolution: {integrity: sha512-Alv8/XGSs/ytwQcbCHwze1HmiIkIVhDHYLjczSVrf0Wi2MvKn/blt7+S6FJitj3yTlMwMxII1gIJ9WepI4aZ/A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-arm64-musl@15.1.9':
     resolution: {integrity: sha512-uZ1HazKcyWC7RA6j+S/8aYgvxmDqwnG+gE5S9MhY7BTMj7ahXKunpKuX8/BA2M7OvINLv7LTzoobQbw928p3WA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-arm64-musl@16.0.7':
     resolution: {integrity: sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@14.2.4':
     resolution: {integrity: sha512-ze0ShQDBPCqxLImzw4sCdfnB3lRmN3qGMB2GWDRlq5Wqy4G36pxtNOo2usu/Nm9+V2Rh/QQnrRc2l94kYFXO6Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-gnu@15.1.9':
     resolution: {integrity: sha512-gQIX1d3ct2RBlgbbWOrp+SHExmtmFm/HSW1Do5sSGMDyzbkYhS2sdq5LRDJWWsQu+/MqpgJHqJT6ORolKp/U1g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-gnu@16.0.7':
     resolution: {integrity: sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@14.2.4':
     resolution: {integrity: sha512-8dwC0UJoc6fC7PX70csdaznVMNr16hQrTDAMPvLPloazlcaWfdPogq+UpZX6Drqb1OBlwowz8iG7WR0Tzk/diQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-musl@15.1.9':
     resolution: {integrity: sha512-fJOwxAbCeq6Vo7pXZGDP6iA4+yIBGshp7ie2Evvge7S7lywyg7b/SGqcvWq/jYcmd0EbXdb7hBfdqSQwTtGTPg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-musl@16.0.7':
     resolution: {integrity: sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@14.2.4':
     resolution: {integrity: sha512-jxyg67NbEWkDyvM+O8UDbPAyYRZqGLQDTPwvrBBeOSyVWW/jFQkQKQ70JDqDSYg1ZDdl+E3nkbFbq8xM8E9x8A==}
@@ -5285,30 +5333,35 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-glibc@2.4.1':
     resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.4.1':
     resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.4.1':
     resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.4.1':
     resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.4.1':
     resolution: {integrity: sha512-/ZR0RxqxU/xxDGzbzosMjh4W6NdYFMqq2nvo2b8SLi7rsl/4jkL8S5stIikorNkdR50oVDvqb/3JT05WM+CRRA==}
@@ -5706,11 +5759,13 @@ packages:
     resolution: {integrity: sha512-ADm/xt86JUnmAfA9mBqFcRp//RVRt1ohGOYF6yL+IFCYqOBNwy5lbEK05xTsEoJq+/tJzg8ICUtS82WinJRuIw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.9.1':
     resolution: {integrity: sha512-Yqz/Doumf3QTKplwGNrCHe/B2p9xqDghBZSlAY0/hU6ikuDVQuOUIpDP/YcmoT+447tsZTmirmjgG3znvSCR0Q==}
@@ -5721,126 +5776,151 @@ packages:
     resolution: {integrity: sha512-tJfJaXPiFAG+Jn3cutp7mCs1ePltuAgRqdDZrzb1aeE3TktWWJ+g7xK9SNlaSUFw6IU4QgOxAY4rA+wZUT5Wfg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.16.4':
     resolution: {integrity: sha512-7dy1BzQkgYlUTapDTvK997cgi0Orh5Iu7JlZVBy1MBURk7/HSbHkzRnXZa19ozy+wwD8/SlpJnOOckuNZtJR9w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.9.1':
     resolution: {integrity: sha512-u3XkZVvxcvlAOlQJ3UsD1rFvLWqu4Ef/Ggl40WAVCuogf4S1nJPHh5RTgqYFpCOvuGJ7H5yGHabjFKEZGExk5Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.16.4':
     resolution: {integrity: sha512-zsFwdUw5XLD1gQe0aoU2HVceI6NEW7q7m05wA46eUAyrkeNYExObfRFQcvA6zw8lfRc5BHtan3tBpo+kqEOxmg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.9.1':
     resolution: {integrity: sha512-0XSYN/rfWShW+i+qjZ0phc6vZ7UWI8XWNz4E/l+6edFt+FxoEghrJHjX1EY/kcUGCnZzYYRCl31SNdfOi450Aw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.16.4':
     resolution: {integrity: sha512-p8C3NnxXooRdNrdv6dBmRTddEapfESEUflpICDNKXpHvTjRRq1J82CbU5G3XfebIZyI3B0s074JHMWD36qOW6w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.16.4':
     resolution: {integrity: sha512-Lh/8ckoar4s4Id2foY7jNgitTOUQczwMWNYi+Mjt0eQ9LKhr6sK477REqQkmy8YHY3Ca3A2JJVdXnfb3Rrwkng==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.9.1':
     resolution: {integrity: sha512-LmYIO65oZVfFt9t6cpYkbC4d5lKHLYv5B4CSHRpnANq0VZUQXGcCPXHzbCXCz4RQnx7jvlYB1ISVNCE/omz5cw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.16.4':
     resolution: {integrity: sha512-1xwwn9ZCQYuqGmulGsTZoKrrn0z2fAur2ujE60QgyDpHmBbXbxLaQiEvzJWDrscRq43c8DnuHx3QorhMTZgisQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.16.4':
     resolution: {integrity: sha512-LuOGGKAJ7dfRtxVnO1i3qWc6N9sh0Em/8aZ3CezixSTM+E9Oq3OvTsvC4sm6wWjzpsIlOCnZjdluINKESflJLA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.9.1':
     resolution: {integrity: sha512-kr8rEPQ6ns/Lmr/hiw8sEVj9aa07gh1/tQF2Y5HrNCCEPiCBGnBUt9tVusrcBBiJfIt1yNaXN6r1CCmpbFEDpg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.16.4':
     resolution: {integrity: sha512-ch86i7KkJKkLybDP2AtySFTRi5fM3KXp0PnHocHuJMdZwu7BuyIKi35BE9guMlmTpwwBTB3ljHj9IQXnTCD0vA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.9.1':
     resolution: {integrity: sha512-t4QSR7gN+OEZLG0MiCgPqMWZGwmeHhsM4AkegJ0Kiy6TnJ9vZ8dEIwHw1LcZKhbHxTY32hp9eVCMdR3/I8MGRw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -5939,41 +6019,49 @@ packages:
     resolution: {integrity: sha512-JB9FAYWjYAeNCPFh0mQu3SZdFHiA+EY37z1AktLDl789SoEec2HPGkvvOs+OIET1pKWgjUGD4Z4Uq4P/r5JFNA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-arm64-gnu@1.2.8':
     resolution: {integrity: sha512-En/SMl45s19iUVb1/ZDFQvFDxIjnlfk7yqV3drMWWAL5HSgksNejaTIFTO52aoohIBbmwuk5wSGcbU0G0IFiPg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@0.5.7':
     resolution: {integrity: sha512-3fNhPvA9Kj/L7rwr2Pj1bvxWBLBgqfkqSvt91iUxPbxgfTiSBQh0Tfb9+hkHv2VCTyNQI/vytkOH+4i4DNXCBw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-arm64-musl@1.2.8':
     resolution: {integrity: sha512-N1oZsXfJ9VLLcK7p1PS65cxLYQCZ7iqHW2OP6Ew2+hlz/d1hzngxgzrtZMCXFOHXDvTzVu5ff6jGS2v7+zv2tA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@0.5.7':
     resolution: {integrity: sha512-y/GnXt1hhbKSqzBSy+ALWwievlejQhIIF8FPXL1kKFh60zl7DE+iYHSJ128jIJiph9dQkBnHw0ABJ5D+vbSqdA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-gnu@1.2.8':
     resolution: {integrity: sha512-BdPaepoLKuaVwip4QK/nGqNi1xpbCWSxiycPbKRrGqKgt/QGihxxFgiqr4EpWQVIJNIMy4nCsg4arO0+H1KWGQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@0.5.7':
     resolution: {integrity: sha512-US/FUv6cvbxbe4nymINwer/EQTvGEgCaAIrvKuAP0yAfK0eyqIHYZj/zCBM2qOS69Mpc2FWVMC/ftRyCvAz/xw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-musl@1.2.8':
     resolution: {integrity: sha512-GFv0Bod268OcXIcjeLoPlK0oz8rClEIxIRFkz+ejhbvfCwRJ+Fd+EKaaKQTBfZQujPqc0h2GctIF25nN5pFTmA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-win32-arm64-msvc@0.5.7':
     resolution: {integrity: sha512-g7NWXa5EGvh6j1VPXGOFaWuOVxdPYYLh3wpUl46Skrd6qFZKB2r+yNhuXo6lqezwYvbtHEDrmFOHF2S6epXO5g==}
@@ -6311,24 +6399,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.13':
     resolution: {integrity: sha512-+ukuB8RHD5BHPCUjQwuLP98z+VRfu+NkKQVBcLJGgp0/+w7y0IkaxLY/aKmrAS5ofCNEGqKL+AOVyRpX1aw+XA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.13':
     resolution: {integrity: sha512-q9H3WI3U3dfJ34tdv60zc8oTuWvSd5fOxytyAO9Pc5M82Hic3jjWaf2xBekUg07ubnMZpyfnv+MlD+EbUI3Llw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.13':
     resolution: {integrity: sha512-9aaZnnq2pLdTbAzTSzy/q8dr7Woy3aYIcQISmw1+Q2/xHJg5y80ZzbWSWKYca/hKonDMjIbGR6dp299I5J0aeA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.13':
     resolution: {integrity: sha512-n3QZmDewkHANcoHvtwvA6yJbmS4XJf0MBMmwLZoKDZ2dOnC9D/jHiXw7JOohEuzYcpLoL5tgbqmjxa3XNo9Oow==}
@@ -6416,24 +6508,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.16':
     resolution: {integrity: sha512-H81UXMa9hJhWhaAUca6bU2wm5RRFpuHImrwXBUvPbYb+3jo32I9VIwpOX6hms0fPmA6f2pGVlybO6qU8pF4fzQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.16':
     resolution: {integrity: sha512-ZGHQxDtFC2/ruo7t99Qo2TTIvOERULPl5l0K1g0oK6b5PGqjYMga+FcY1wIUnrUxY56h28FxybtDEla+ICOyew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.16':
     resolution: {integrity: sha512-Oi1tAaa0rcKf1Og9MzKeINZzMLPbhxvm7rno5/zuP1WYmpiG0bEHq4AcRUiG2165/WUzvxkW4XDYCscZWbTLZw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.16':
     resolution: {integrity: sha512-B01u/b8LteGRwucIBmCQ07FVXLzImWESAIMcUU6nvFt/tYsQ6IHz8DmZ5KtvmwxD+iTYBtM1xwoGXswnlu9v0Q==}
@@ -7159,24 +7255,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@umijs/es-module-parser-linux-arm64-musl@0.0.7':
     resolution: {integrity: sha512-cqQffARWkmQ3n1RYNKZR3aD6X8YaP6u1maASjDgPQOpZMAlv/OSDrM/7iGujWTs0PD0haockNG9/DcP6lgPHMw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@umijs/es-module-parser-linux-x64-gnu@0.0.7':
     resolution: {integrity: sha512-PHrKHtT665Za0Ydjch4ACrNpRU+WIIden12YyF1CtMdhuLDSoU6UfdhF3NoDbgEUcXVDX/ftOqmj0SbH3R1uew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@umijs/es-module-parser-linux-x64-musl@0.0.7':
     resolution: {integrity: sha512-cyZvUK5lcECLWzLp/eU1lFlCETcz+LEb+wrdARQSST1dgoIGZsT4cqM1WzYmdZNk3o883tiZizLt58SieEiHBQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@umijs/es-module-parser-win32-arm64-msvc@0.0.7':
     resolution: {integrity: sha512-V7WxnUI88RboSl0RWLNQeKBT7EDW35fW6Tn92zqtoHHxrhAIL9DtDyvC8REP4qTxeZ6Oej/Ax5I6IjsLx3yTOg==}
@@ -7217,24 +7317,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@umijs/mako-linux-arm64-musl@0.11.10':
     resolution: {integrity: sha512-kqI1Jw6IHtDwrcsqPZrYxsV3pHzZyOR+6fCFnF5MSURnXbUbJb6Rk66VsKKpMqbyfsEO6nt0WT9FrRBlFvRU2A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@umijs/mako-linux-x64-gnu@0.11.10':
     resolution: {integrity: sha512-jlhXVvWJuumMmiE3z3ViugOMx9ZasNM1anng0PsusCgDwfy0IOfGzfwfwagqtzfsC5MwyRcfnRQyDdbfbroaSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@umijs/mako-linux-x64-musl@0.11.10':
     resolution: {integrity: sha512-SLV/PRdL12dFEKlQGenW3OboZXmdYi25y+JblgVJLBhpdxZrHFqpCsTZn4L3hVEhyl0/ksR1iY0wtfK3urR29g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@umijs/mako-win32-ia32-msvc@0.11.10':
     resolution: {integrity: sha512-quCWpVl7yQjG+ccGhkF81GxO3orXdPW1OZWXWxJgOI0uPk7Hczh2EYMEVqqQGbi/83eJ1e3iE1jRTl/+2eHryQ==}
@@ -7322,6 +7426,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/dom@1.9.14':
     resolution: {integrity: sha512-XZSZ2Wmm1Sv7k9scSFGrarbteSIl3p3I3oOUprKPDboBTvuG5q81Qz8O99NKUGKGJ8BKUkxCqE982eH3S8DKJA==}
@@ -8177,11 +8282,6 @@ packages:
 
   acorn@8.12.0:
     resolution: {integrity: sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.14.0:
-    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -10879,10 +10979,6 @@ packages:
     resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.16.0:
-    resolution: {integrity: sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==}
-    engines: {node: '>=10.13.0'}
-
   enhanced-resolve@5.18.2:
     resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
     engines: {node: '>=10.13.0'}
@@ -11899,9 +11995,6 @@ packages:
   flatted@2.0.2:
     resolution: {integrity: sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==}
 
-  flatted@3.2.7:
-    resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
-
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
@@ -12270,12 +12363,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -13526,10 +13619,6 @@ packages:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
 
-  istanbul-lib-report@3.0.0:
-    resolution: {integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==}
-    engines: {node: '>=8'}
-
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
@@ -13541,10 +13630,6 @@ packages:
   istanbul-lib-source-maps@5.0.6:
     resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
-
-  istanbul-reports@3.1.5:
-    resolution: {integrity: sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==}
-    engines: {node: '>=8'}
 
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
@@ -14112,48 +14197,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.22.1:
     resolution: {integrity: sha512-MCV6RuRpzXbunvzwY644iz8cw4oQxvW7oer9xPkdadYqlEyiJJ6wl7FyJOH7Q6ZYH4yjGAUCvxDBxPbnDu9ZVg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.22.1:
     resolution: {integrity: sha512-RjNgpdM20VUXgV7us/VmlO3Vn2ZRiDnc3/bUxCVvySZWPiVPprpqW/QDWuzkGa+NCUf6saAM5CLsZLSxncXJwg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.22.1:
     resolution: {integrity: sha512-ZgO4C7Rd6Hv/5MnyY2KxOYmIlzk4rplVolDt3NbkNR8DndnyX0Q5IR4acJWNTBICQ21j3zySzKbcJaiJpk/4YA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -15367,9 +15460,6 @@ packages:
 
   nwsapi@2.2.13:
     resolution: {integrity: sha512-cTGB9ptp9dY9A5VbMSe7fQBcl/tt22Vcqdq8+eN93rblOuE0aCFu4aZ2vMwct/2t+lFnosm8RkQW1I0Omb1UtQ==}
-
-  nwsapi@2.2.7:
-    resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
 
   nypm@0.3.8:
     resolution: {integrity: sha512-IGWlC6So2xv6V4cIDmoV0SwwWx7zLG086gyqkyumteH2fIgCAM4nDVFB2iDRszDvmdSVW9xb1N+2KjQ6C7d4og==}
@@ -16840,6 +16930,7 @@ packages:
   prebuild-install@7.1.1:
     resolution: {integrity: sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   preferred-pm@3.1.2:
@@ -19691,6 +19782,7 @@ packages:
   tsconfck@3.0.2:
     resolution: {integrity: sha512-6lWtFjwuhS3XI4HsX4Zg0izOI3FU/AI9EGVlPEUMDIhvLPMD4wkiof0WCoDgW7qY+Dy198g4d9miAqUHWHFH6Q==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -20128,6 +20220,7 @@ packages:
 
   unplugin-vue-router@0.7.0:
     resolution: {integrity: sha512-ddRreGq0t5vlSB7OMy4e4cfU1w2AwBQCwmvW3oP/0IHQiokzbx4hd3TpwBu3eIAFVuhX2cwNQwp1U32UybTVCw==}
+    deprecated: 'Merged into vuejs/router. Migrate: https://router.vuejs.org/guide/migration/v4-to-v5.html'
     peerDependencies:
       vue-router: ^4.1.0
     peerDependenciesMeta:
@@ -20401,11 +20494,12 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -21426,10 +21520,12 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.2:
     resolution: {integrity: sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==}
@@ -22264,7 +22360,6 @@ snapshots:
       '@img/sharp-linuxmusl-arm64': 0.33.5
       '@img/sharp-linuxmusl-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
-    optional: true
 
   '@antv/adjust@0.2.5':
     dependencies:
@@ -22580,7 +22675,7 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/telemetry@3.0.4':
+  '@astrojs/telemetry@3.0.4(supports-color@6.1.0)':
     dependencies:
       ci-info: 3.8.0
       debug: 4.3.7(supports-color@6.1.0)
@@ -22672,10 +22767,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.24.7
       '@babel/helper-module-transforms': 7.24.7(@babel/core@7.24.7)
       '@babel/helpers': 7.24.7
-      '@babel/parser': 7.26.2
+      '@babel/parser': 7.29.7
       '@babel/template': 7.24.7
       '@babel/traverse': 7.24.7
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
       convert-source-map: 2.0.0
       debug: 4.3.7(supports-color@6.1.0)
       gensync: 1.0.0-beta.2
@@ -22692,15 +22787,6 @@ snapshots:
       eslint: 8.28.0
       eslint-visitor-keys: 2.1.0
 
-  '@babel/eslint-parser@7.23.3(@babel/core@7.21.3)(eslint@8.28.0)':
-    dependencies:
-      '@babel/core': 7.21.3
-      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.28.0
-      eslint-visitor-keys: 2.1.0
-      semver: 6.3.1
-    optional: true
-
   '@babel/eslint-parser@7.23.3(@babel/core@7.23.6)(eslint@9.39.1(jiti@2.6.1))':
     dependencies:
       '@babel/core': 7.23.6
@@ -22708,6 +22794,15 @@ snapshots:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
+
+  '@babel/eslint-parser@7.23.3(@babel/core@7.24.7)(eslint@8.28.0)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
+      eslint: 8.28.0
+      eslint-visitor-keys: 2.1.0
+      semver: 6.3.1
+    optional: true
 
   '@babel/generator@7.2.0':
     dependencies:
@@ -22733,7 +22828,7 @@ snapshots:
 
   '@babel/generator@7.24.7':
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
@@ -22748,7 +22843,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.24.7':
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.22.5':
     dependencies:
@@ -22775,7 +22870,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.24.7
       '@babel/helper-validator-option': 7.24.7
-      browserslist: 4.22.2
+      browserslist: 4.23.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -22858,7 +22953,7 @@ snapshots:
       regexpu-core: 5.3.1
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.21.3)':
+  '@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.21.3)(supports-color@6.1.0)':
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-compilation-targets': 7.23.6
@@ -22870,7 +22965,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-define-polyfill-provider@0.4.0(@babel/core@7.21.3)':
+  '@babel/helper-define-polyfill-provider@0.4.0(@babel/core@7.21.3)(supports-color@6.1.0)':
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-compilation-targets': 7.22.5(@babel/core@7.21.3)
@@ -22890,7 +22985,7 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-function-name@7.21.0':
     dependencies:
@@ -22910,7 +23005,7 @@ snapshots:
   '@babel/helper-function-name@7.24.7':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-hoist-variables@7.22.5':
     dependencies:
@@ -22918,7 +23013,7 @@ snapshots:
 
   '@babel/helper-hoist-variables@7.24.7':
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-member-expression-to-functions@7.21.0':
     dependencies:
@@ -22954,7 +23049,7 @@ snapshots:
   '@babel/helper-module-imports@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.7
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -23082,7 +23177,7 @@ snapshots:
   '@babel/helper-simple-access@7.24.7':
     dependencies:
       '@babel/traverse': 7.24.7
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -23111,7 +23206,7 @@ snapshots:
 
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-string-parser@7.23.4': {}
 
@@ -23161,7 +23256,7 @@ snapshots:
   '@babel/helpers@7.24.7':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -23286,11 +23381,6 @@ snapshots:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -23301,11 +23391,6 @@ snapshots:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -23314,11 +23399,6 @@ snapshots:
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.22.5
-
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.7)':
@@ -23354,7 +23434,7 @@ snapshots:
   '@babel/plugin-syntax-flow@7.22.5(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.21.3)':
     dependencies:
@@ -23391,11 +23471,6 @@ snapshots:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -23414,26 +23489,21 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.6)':
     dependencies:
       '@babel/core': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.22.5
-
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.7)':
@@ -23446,11 +23516,6 @@ snapshots:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -23459,11 +23524,6 @@ snapshots:
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.22.5
-
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.7)':
@@ -23476,11 +23536,6 @@ snapshots:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -23491,11 +23546,6 @@ snapshots:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -23504,11 +23554,6 @@ snapshots:
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.22.5
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.7)':
@@ -23526,11 +23571,6 @@ snapshots:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
-
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
@@ -23544,11 +23584,6 @@ snapshots:
   '@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.22.5
-
-  '@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.23.6)':
-    dependencies:
-      '@babel/core': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.23.6)':
@@ -23851,17 +23886,27 @@ snapshots:
   '@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
+
+  '@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    optional: true
 
   '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.21.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-react-jsx-self@7.22.5(@babel/core@7.21.3)':
     dependencies:
@@ -23895,35 +23940,48 @@ snapshots:
   '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.21.3)
-      '@babel/types': 7.23.6
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.23.6)':
     dependencies:
       '@babel/core': 7.23.6
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.6)
-      '@babel/types': 7.23.6
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.24.7)':
     dependencies:
       '@babel/core': 7.24.7
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.24.7)
-      '@babel/types': 7.23.6
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+
+  '@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+    optional: true
 
   '@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.21.3)':
     dependencies:
@@ -23936,12 +23994,12 @@ snapshots:
       '@babel/core': 7.21.3
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/plugin-transform-runtime@7.21.0(@babel/core@7.21.3)':
+  '@babel/plugin-transform-runtime@7.21.0(@babel/core@7.21.3)(supports-color@6.1.0)':
     dependencies:
       '@babel/core': 7.21.3
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
-      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.3)
+      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.3)(supports-color@6.1.0)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.21.3)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.21.3)
       semver: 6.3.1
@@ -24035,7 +24093,7 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.5(@babel/core@7.21.3)
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/preset-env@7.22.5(@babel/core@7.21.3)':
+  '@babel/preset-env@7.22.5(@babel/core@7.21.3)(supports-color@6.1.0)':
     dependencies:
       '@babel/compat-data': 7.22.5
       '@babel/core': 7.21.3
@@ -24113,7 +24171,7 @@ snapshots:
       '@babel/plugin-transform-unicode-sets-regex': 7.22.5(@babel/core@7.21.3)
       '@babel/preset-modules': 0.1.5(@babel/core@7.21.3)
       '@babel/types': 7.24.7
-      babel-plugin-polyfill-corejs2: 0.4.3(@babel/core@7.21.3)
+      babel-plugin-polyfill-corejs2: 0.4.3(@babel/core@7.21.3)(supports-color@6.1.0)
       babel-plugin-polyfill-corejs3: 0.8.1(@babel/core@7.21.3)
       babel-plugin-polyfill-regenerator: 0.5.0(@babel/core@7.21.3)
       core-js-compat: 3.31.0
@@ -24133,12 +24191,27 @@ snapshots:
   '@babel/preset-react@7.22.5(@babel/core@7.21.3)':
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
       '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.21.3)
-      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.21.3)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.21.3)
       '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.21.3)
       '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.21.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-react@7.22.5(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
+      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@babel/preset-typescript@7.22.5(@babel/core@7.21.3)':
     dependencies:
@@ -24194,8 +24267,8 @@ snapshots:
   '@babel/template@7.24.7':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.22.5':
     dependencies:
@@ -24250,8 +24323,8 @@ snapshots:
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-hoist-variables': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       debug: 4.3.7(supports-color@6.1.0)
       globals: 11.12.0
     transitivePeerDependencies:
@@ -24981,9 +25054,9 @@ snapshots:
       eslint: 8.28.0
       eslint-visitor-keys: 3.4.1
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.18.0(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.4.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))':
     dependencies:
-      eslint: 9.18.0(jiti@2.6.1)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       eslint-visitor-keys: 3.4.1
 
   '@eslint-community/eslint-utils@4.4.0(eslint@9.39.1(jiti@2.6.1))':
@@ -24998,7 +25071,7 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/config-array@0.19.1':
+  '@eslint/config-array@0.19.1(supports-color@6.1.0)':
     dependencies:
       '@eslint/object-schema': 2.1.5
       debug: 4.3.7(supports-color@6.1.0)
@@ -25026,7 +25099,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@1.4.1':
+  '@eslint/eslintrc@1.4.1(supports-color@6.1.0)':
     dependencies:
       ajv: 6.12.6
       debug: 4.3.7(supports-color@6.1.0)
@@ -25120,7 +25193,7 @@ snapshots:
   '@farmfe/core-win32-x64-msvc@1.2.8':
     optional: true
 
-  '@farmfe/core@1.2.8(bufferutil@4.0.8)(utf-8-validate@6.0.4)':
+  '@farmfe/core@1.2.8(bufferutil@4.0.8)(supports-color@6.1.0)(utf-8-validate@6.0.4)':
     dependencies:
       '@farmfe/runtime': 0.11.2
       '@farmfe/runtime-plugin-hmr': 3.5.2
@@ -25136,12 +25209,12 @@ snapshots:
       farm-browserslist-generator: 1.0.0
       fast-glob: 3.3.2
       fs-extra: 11.2.0
-      http-proxy-middleware: 3.0.0
+      http-proxy-middleware: 3.0.0(supports-color@6.1.0)
       is-plain-object: 5.0.0
-      koa: 2.15.3
+      koa: 2.15.3(supports-color@6.1.0)
       koa-compress: 5.1.1
       koa-connect: 2.1.0
-      koa-static: 5.0.0
+      koa-static: 5.0.0(supports-color@6.1.0)
       lodash.debounce: 4.0.8
       loglevel: 1.8.1
       mime-types: 2.1.35
@@ -25254,7 +25327,7 @@ snapshots:
       '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.3.1
 
-  '@humanwhocodes/config-array@0.11.10':
+  '@humanwhocodes/config-array@0.11.10(supports-color@6.1.0)':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
       debug: 4.3.7(supports-color@6.1.0)
@@ -25274,7 +25347,7 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@iconify/utils@2.1.1':
+  '@iconify/utils@2.1.1(supports-color@6.1.0)':
     dependencies:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.7.8
@@ -25598,11 +25671,11 @@ snapshots:
       exit: 0.1.2
       glob: 7.2.3
       graceful-fs: 4.2.11
-      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 5.2.1
-      istanbul-lib-report: 3.0.0
+      istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 4.0.1
-      istanbul-reports: 3.1.5
+      istanbul-reports: 3.1.7
       jest-haste-map: 27.5.1
       jest-resolve: 27.5.1
       jest-util: 27.5.1
@@ -25782,7 +25855,7 @@ snapshots:
     dependencies:
       vary: 1.1.2
 
-  '@kwsites/file-exists@1.1.1':
+  '@kwsites/file-exists@1.1.1(supports-color@6.1.0)':
     dependencies:
       debug: 4.3.7(supports-color@6.1.0)
     transitivePeerDependencies:
@@ -26151,8 +26224,8 @@ snapshots:
 
   '@npmcli/agent@2.2.2':
     dependencies:
-      agent-base: 7.1.1
-      http-proxy-agent: 7.0.2
+      agent-base: 7.1.1(supports-color@6.1.0)
+      http-proxy-agent: 7.0.2(supports-color@6.1.0)
       https-proxy-agent: 7.0.4
       lru-cache: 10.2.0
       socks-proxy-agent: 8.0.3
@@ -26163,7 +26236,7 @@ snapshots:
     dependencies:
       semver: 7.8.3
 
-  '@npmcli/git@5.0.7':
+  '@npmcli/git@5.0.7(bluebird@3.7.2)':
     dependencies:
       '@npmcli/promise-spawn': 7.0.2
       lru-cache: 10.2.0
@@ -26185,7 +26258,7 @@ snapshots:
 
   '@npmcli/package-json@5.2.0':
     dependencies:
-      '@npmcli/git': 5.0.7
+      '@npmcli/git': 5.0.7(bluebird@3.7.2)
       glob: 10.4.5
       hosted-git-info: 7.0.2
       json-parse-even-better-errors: 3.0.1
@@ -26239,7 +26312,7 @@ snapshots:
       rc9: 2.1.2
       semver: 7.8.3
 
-  '@nuxt/devtools@1.3.6(bufferutil@4.0.8)(rollup@4.16.4)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))':
+  '@nuxt/devtools@1.3.6(bluebird@3.7.2)(bufferutil@4.0.8)(rollup@4.16.4)(supports-color@6.1.0)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))':
     dependencies:
       '@antfu/utils': 0.7.8
       '@nuxt/devtools-kit': 1.3.6(magicast@0.3.5)(rollup@4.16.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
@@ -26264,18 +26337,18 @@ snapshots:
       magicast: 0.3.5
       nypm: 0.3.8
       ohash: 1.1.3
-      pacote: 18.0.6
+      pacote: 18.0.6(bluebird@3.7.2)(supports-color@6.1.0)
       pathe: 1.1.2
       perfect-debounce: 1.0.0
       pkg-types: 1.1.1
       rc9: 2.1.2
       scule: 1.3.0
       semver: 7.7.2
-      simple-git: 3.25.0
+      simple-git: 3.25.0(supports-color@6.1.0)
       sirv: 2.0.4
       unimport: 3.7.2(rollup@4.16.4)
       vite: 5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)
-      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.12.2(magicast@0.3.5)(rollup@4.16.4))(rollup@4.16.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
+      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.12.2(magicast@0.3.5)(rollup@4.16.4))(rollup@4.16.4)(supports-color@6.1.0)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
       vite-plugin-vue-inspector: 5.1.2(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
       which: 3.0.1
       ws: 8.18.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
@@ -26355,7 +26428,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/vite-builder@3.12.2(@types/node@24.10.0)(eslint@9.39.1(jiti@2.6.1))(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(vue@3.4.30(typescript@5.9.3))':
+  '@nuxt/vite-builder@3.12.2(@types/node@24.10.0)(eslint@9.39.1(jiti@2.6.1))(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(supports-color@6.1.0)(terser@5.30.4)(typescript@5.9.3)(vue@3.4.30(typescript@5.9.3))':
     dependencies:
       '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.16.4)
       '@rollup/plugin-replace': 5.0.7(rollup@4.16.4)
@@ -26388,7 +26461,7 @@ snapshots:
       unenv: 1.9.0
       unplugin: 1.10.1
       vite: 5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)
-      vite-node: 1.6.0(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)
+      vite-node: 1.6.0(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(supports-color@6.1.0)(terser@5.30.4)
       vite-plugin-checker: 0.6.4(eslint@9.39.1(jiti@2.6.1))(meow@9.0.0)(optionator@0.9.4)(stylelint@14.16.1)(typescript@5.9.3)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
       vue: 3.4.30(typescript@5.9.3)
       vue-bundle-renderer: 2.1.0
@@ -27631,10 +27704,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/tuf@2.3.4':
+  '@sigstore/tuf@2.3.4(supports-color@6.1.0)':
     dependencies:
       '@sigstore/protobuf-specs': 0.3.2
-      tuf-js: 2.2.1
+      tuf-js: 2.2.1(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27683,18 +27756,18 @@ snapshots:
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.12
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)))(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(supports-color@6.1.0)(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)))(supports-color@6.1.0)(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(supports-color@6.1.0)(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))
       debug: 4.3.7(supports-color@6.1.0)
       svelte: 4.2.18
       vite: 5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))':
+  '@sveltejs/vite-plugin-svelte@3.1.1(supports-color@6.1.0)(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)))(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(supports-color@6.1.0)(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)))(supports-color@6.1.0)(svelte@4.2.18)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))
       debug: 4.3.5
       deepmerge: 4.3.1
       kleur: 4.1.5
@@ -27828,11 +27901,11 @@ snapshots:
       deepmerge: 4.3.1
       svgo: 2.8.0
 
-  '@svgr/webpack@5.5.0':
+  '@svgr/webpack@5.5.0(supports-color@6.1.0)':
     dependencies:
       '@babel/core': 7.21.3
       '@babel/plugin-transform-react-constant-elements': 7.22.5(@babel/core@7.21.3)
-      '@babel/preset-env': 7.22.5(@babel/core@7.21.3)
+      '@babel/preset-env': 7.22.5(@babel/core@7.21.3)(supports-color@6.1.0)
       '@babel/preset-react': 7.22.5(@babel/core@7.21.3)
       '@svgr/core': 5.5.0
       '@svgr/plugin-jsx': 5.5.0
@@ -28065,24 +28138,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.23.6
-      '@babel/types': 7.23.6
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.20.1
 
   '@types/babel__generator@7.6.4':
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.1':
     dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.20.1':
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
 
   '@types/body-parser@1.19.2':
     dependencies:
@@ -28120,7 +28193,7 @@ snapshots:
   '@types/eslint-scope@3.7.4':
     dependencies:
       '@types/eslint': 8.44.0
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
 
   '@types/eslint@7.29.0':
     dependencies:
@@ -28474,11 +28547,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(typescript@4.9.5)':
+  '@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/parser': 5.44.0(eslint@8.28.0)(typescript@4.9.5)
       '@typescript-eslint/scope-manager': 5.44.0
-      '@typescript-eslint/type-utils': 5.44.0(eslint@8.28.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 5.44.0(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 5.44.0(eslint@8.28.0)(typescript@4.9.5)
       debug: 4.3.4
       eslint: 8.28.0
@@ -28492,14 +28565,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)':
+  '@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)':
     dependencies:
-      '@typescript-eslint/parser': 5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)
+      '@typescript-eslint/parser': 5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)
       '@typescript-eslint/scope-manager': 5.44.0
-      '@typescript-eslint/type-utils': 5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)
-      '@typescript-eslint/utils': 5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)
+      '@typescript-eslint/type-utils': 5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)
+      '@typescript-eslint/utils': 5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)
       debug: 4.3.4
-      eslint: 9.18.0(jiti@2.6.1)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
@@ -28510,12 +28583,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)':
+  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2)
       '@typescript-eslint/utils': 5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)
       debug: 4.3.7(supports-color@6.1.0)
       eslint: 9.39.1(jiti@2.6.1)
@@ -28529,12 +28602,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.46.3
-      '@typescript-eslint/type-utils': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)
       '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.3
       eslint: 9.39.1(jiti@2.6.1)
@@ -28579,6 +28652,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.44.0
+      '@typescript-eslint/types': 5.44.0
+      '@typescript-eslint/typescript-estree': 5.44.0(typescript@5.4.5)
+      debug: 4.3.4
+      eslint: 8.28.0(supports-color@6.1.0)
+    optionalDependencies:
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.44.0
@@ -28591,31 +28676,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.44.0
-      '@typescript-eslint/types': 5.44.0
-      '@typescript-eslint/typescript-estree': 5.44.0(typescript@5.4.5)
-      debug: 4.3.4
-      eslint: 8.28.0
-    optionalDependencies:
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)':
+  '@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.44.0
       '@typescript-eslint/types': 5.44.0
       '@typescript-eslint/typescript-estree': 5.44.0(typescript@5.5.3)
       debug: 4.3.4
-      eslint: 9.18.0(jiti@2.6.1)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
     optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)':
+  '@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
@@ -28627,7 +28700,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.3
       '@typescript-eslint/types': 8.46.3
@@ -28672,7 +28745,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@5.44.0(eslint@8.28.0)(typescript@4.9.5)':
+  '@typescript-eslint/type-utils@5.44.0(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.44.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.44.0(eslint@8.28.0)(typescript@4.9.5)
@@ -28684,19 +28757,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)':
+  '@typescript-eslint/type-utils@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.44.0(typescript@5.5.3)
-      '@typescript-eslint/utils': 5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)
+      '@typescript-eslint/utils': 5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)
       debug: 4.3.7(supports-color@6.1.0)
-      eslint: 9.18.0(jiti@2.6.1)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       tsutils: 3.21.0(typescript@5.5.3)
     optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)':
+  '@typescript-eslint/type-utils@5.62.0(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.2)
       '@typescript-eslint/utils': 5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)
@@ -28708,7 +28781,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.46.3
       '@typescript-eslint/typescript-estree': 8.46.3(typescript@5.9.3)
@@ -28843,16 +28916,16 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)':
+  '@typescript-eslint/utils@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)':
     dependencies:
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.0
       '@typescript-eslint/scope-manager': 5.44.0
       '@typescript-eslint/types': 5.44.0
       '@typescript-eslint/typescript-estree': 5.44.0(typescript@5.5.3)
-      eslint: 9.18.0(jiti@2.6.1)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@9.18.0(jiti@2.6.1))
+      eslint-utils: 3.0.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
@@ -28946,7 +29019,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@umijs/bundler-mako@0.11.10(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(postcss@8.5.3)(sass-embedded@1.79.4)(sass@1.54.7)(typescript@5.8.2)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))':
+  '@umijs/bundler-mako@0.11.10(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(postcss@8.5.3)(sass-embedded@1.79.4)(sass@1.54.7)(supports-color@6.1.0)(typescript@5.8.2)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))':
     dependencies:
       '@umijs/bundler-utils': 4.4.12
       '@umijs/mako': 0.11.10(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(postcss@8.5.3)(sass-embedded@1.79.4)(sass@1.54.7)(typescript@5.8.2)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))
@@ -28955,7 +29028,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       cors: 2.8.5
       express: 4.21.2
-      express-http-proxy: 2.1.1
+      express-http-proxy: 2.1.1(supports-color@6.1.0)
       get-tsconfig: 4.7.5
       lodash: 4.17.21
       rimraf: 5.0.1
@@ -29092,15 +29165,15 @@ snapshots:
       '@babel/runtime': 7.23.6
       query-string: 6.14.1
 
-  '@umijs/lint@4.4.12(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(stylelint@14.16.1)(typescript@5.8.2)':
+  '@umijs/lint@4.4.12(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(stylelint@14.16.1)(supports-color@6.1.0)(typescript@5.8.2)':
     dependencies:
       '@babel/core': 7.23.6
       '@babel/eslint-parser': 7.23.3(@babel/core@7.23.6)(eslint@9.39.1(jiti@2.6.1))
       '@stylelint/postcss-css-in-js': 0.38.0(postcss-syntax@0.36.2(postcss@8.5.3))(postcss@8.5.3)
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)
-      '@typescript-eslint/parser': 5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2)
       '@umijs/babel-preset-umi': 4.4.12
-      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(typescript@5.8.2)
+      eslint-plugin-jest: 27.2.3(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(typescript@5.8.2)
       eslint-plugin-react: 7.33.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 4.6.0(eslint@9.39.1(jiti@2.6.1))
       postcss: 8.5.3
@@ -29195,15 +29268,15 @@ snapshots:
     dependencies:
       tsx: 3.12.2
 
-  '@umijs/preset-umi@4.4.12(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(@types/node@24.10.0)(@types/react@18.3.3)(@types/webpack@4.41.33)(lightningcss@1.30.2)(rollup@3.29.4)(sass-embedded@1.79.4)(sass@1.54.7)(sockjs-client@1.6.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(type-fest@3.13.1)(typescript@5.8.2)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))':
+  '@umijs/preset-umi@4.4.12(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(@types/node@24.10.0)(@types/react@18.3.3)(@types/webpack@4.41.33)(lightningcss@1.30.2)(rollup@3.29.4)(sass-embedded@1.79.4)(sass@1.54.7)(sockjs-client@1.6.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(supports-color@6.1.0)(terser@5.30.4)(type-fest@3.13.1)(typescript@5.8.2)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))':
     dependencies:
-      '@iconify/utils': 2.1.1
+      '@iconify/utils': 2.1.1(supports-color@6.1.0)
       '@stagewise/toolbar': 0.6.2
       '@svgr/core': 6.5.1
       '@umijs/ast': 4.4.12
       '@umijs/babel-preset-umi': 4.4.12
       '@umijs/bundler-esbuild': 4.4.12
-      '@umijs/bundler-mako': 0.11.10(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(postcss@8.5.3)(sass-embedded@1.79.4)(sass@1.54.7)(typescript@5.8.2)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))
+      '@umijs/bundler-mako': 0.11.10(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(postcss@8.5.3)(sass-embedded@1.79.4)(sass@1.54.7)(supports-color@6.1.0)(typescript@5.8.2)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))
       '@umijs/bundler-utils': 4.4.12
       '@umijs/bundler-vite': 4.4.12(@types/node@24.10.0)(lightningcss@1.30.2)(postcss@8.5.3)(rollup@3.29.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)
       '@umijs/bundler-webpack': 4.4.12(@types/webpack@4.41.33)(sockjs-client@1.6.1)(type-fest@3.13.1)(typescript@5.8.2)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))
@@ -29285,6 +29358,16 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  '@umijs/renderer-react@4.4.12(react-dom@19.2.1(react@19.2.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.23.6
+      '@loadable/component': 5.15.2(react@18.3.1)
+      history: 5.3.0
+      react: 18.3.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-helmet-async: 1.3.0(react-dom@19.2.1(react@19.2.1))(react@18.3.1)
+      react-router-dom: 6.3.0(react-dom@19.2.1(react@19.2.1))(react@18.3.1)
 
   '@umijs/route-utils@2.2.2':
     dependencies:
@@ -29470,21 +29553,21 @@ snapshots:
       vite: 7.3.5(@types/node@24.10.0)(jiti@2.6.1)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)(yaml@2.9.0)
       vue: 3.4.30(typescript@5.9.3)
 
-  '@vitest/coverage-v8@2.1.4(vitest@2.1.4(@types/node@20.14.11)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@6.0.4))(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))':
+  '@vitest/coverage-v8@2.1.4(supports-color@6.1.0)(vitest@2.1.4(@types/node@20.14.11)(jsdom@25.0.1(bufferutil@4.0.8)(supports-color@6.1.0)(utf-8-validate@6.0.4))(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(supports-color@6.1.0)(terser@5.30.4))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
       debug: 4.3.7(supports-color@6.1.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
+      istanbul-lib-source-maps: 5.0.6(supports-color@6.1.0)
       istanbul-reports: 3.1.7
       magic-string: 0.30.12
       magicast: 0.3.5
       std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.4(@types/node@20.14.11)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@6.0.4))(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)
+      vitest: 2.1.4(@types/node@20.14.11)(jsdom@25.0.1(bufferutil@4.0.8)(supports-color@6.1.0)(utf-8-validate@6.0.4))(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(supports-color@6.1.0)(terser@5.30.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -29672,9 +29755,9 @@ snapshots:
       '@volar/language-core': 1.3.0-alpha.0
       '@volar/source-map': 1.3.0-alpha.0
       '@vue/compiler-dom': 3.5.13
-      '@vue/compiler-sfc': 3.3.4
-      '@vue/reactivity': 3.3.4
-      '@vue/shared': 3.4.30
+      '@vue/compiler-sfc': 3.5.13
+      '@vue/reactivity': 3.5.13
+      '@vue/shared': 3.5.13
       minimatch: 6.2.0
       muggle-string: 0.2.2
       vue-template-compiler: 2.7.14
@@ -29817,8 +29900,8 @@ snapshots:
       '@babel/plugin-proposal-decorators': 7.22.7(@babel/core@7.21.3)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.3)
       '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.21.3)
-      '@babel/plugin-transform-runtime': 7.21.0(@babel/core@7.21.3)
-      '@babel/preset-env': 7.22.5(@babel/core@7.21.3)
+      '@babel/plugin-transform-runtime': 7.21.0(@babel/core@7.21.3)(supports-color@6.1.0)
+      '@babel/preset-env': 7.22.5(@babel/core@7.21.3)(supports-color@6.1.0)
       '@babel/runtime': 7.21.0
       '@vue/babel-plugin-jsx': 1.1.1(@babel/core@7.21.3)
       '@vue/babel-preset-jsx': 1.4.0(@babel/core@7.21.3)(vue@3.2.47)
@@ -31034,8 +31117,6 @@ snapshots:
 
   acorn@8.12.0: {}
 
-  acorn@8.14.0: {}
-
   acorn@8.16.0: {}
 
   add-dom-event-listener@1.1.0:
@@ -31055,7 +31136,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  agent-base@7.1.1:
+  agent-base@7.1.1(supports-color@6.1.0):
     dependencies:
       debug: 4.3.7(supports-color@6.1.0)
     transitivePeerDependencies:
@@ -31088,17 +31169,17 @@ snapshots:
     dependencies:
       ajv: 6.12.6
 
-  ajv-formats@2.1.1(ajv@8.12.0):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.12.0
+      ajv: 8.20.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
       ajv: 6.12.6
 
-  ajv-keywords@5.1.0(ajv@8.12.0):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.12.0
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -31573,12 +31654,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@4.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)(typescript@5.3.3):
+  astro@4.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(supports-color@6.1.0)(terser@5.30.4)(typescript@5.3.3):
     dependencies:
       '@astrojs/compiler': 2.5.3
       '@astrojs/internal-helpers': 0.2.1
       '@astrojs/markdown-remark': 4.2.1
-      '@astrojs/telemetry': 3.0.4
+      '@astrojs/telemetry': 3.0.4(supports-color@6.1.0)
       '@babel/core': 7.23.6
       '@babel/generator': 7.23.6
       '@babel/parser': 7.23.6
@@ -31835,7 +31916,7 @@ snapshots:
 
   axe-core@4.7.2: {}
 
-  axios@0.27.2:
+  axios@0.27.2(debug@4.3.4):
     dependencies:
       follow-redirects: 1.15.2(debug@4.3.4)
       form-data: 4.0.0
@@ -31843,6 +31924,15 @@ snapshots:
       - debug
 
   axios@1.2.0:
+    dependencies:
+      follow-redirects: 1.15.2(debug@4.3.7(supports-color@6.1.0))
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    optional: true
+
+  axios@1.2.0(debug@4.3.4):
     dependencies:
       follow-redirects: 1.15.2(debug@4.3.4)
       form-data: 4.0.0
@@ -31896,14 +31986,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-jest@27.5.1(@babel/core@7.23.6):
+  babel-jest@27.5.1(@babel/core@7.24.7):
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.24.7
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 27.5.1(@babel/core@7.23.6)
+      babel-preset-jest: 27.5.1(@babel/core@7.24.7)
       chalk: 4.1.1
       graceful-fs: 4.2.11
       slash: 3.0.0
@@ -31988,20 +32078,20 @@ snapshots:
     dependencies:
       '@babel/core': 7.21.3
 
-  babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.21.3):
+  babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.21.3)(supports-color@6.1.0):
     dependencies:
       '@babel/compat-data': 7.22.5
       '@babel/core': 7.21.3
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.3)
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.3)(supports-color@6.1.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs2@0.4.3(@babel/core@7.21.3):
+  babel-plugin-polyfill-corejs2@0.4.3(@babel/core@7.21.3)(supports-color@6.1.0):
     dependencies:
       '@babel/compat-data': 7.22.5
       '@babel/core': 7.21.3
-      '@babel/helper-define-polyfill-provider': 0.4.0(@babel/core@7.21.3)
+      '@babel/helper-define-polyfill-provider': 0.4.0(@babel/core@7.21.3)(supports-color@6.1.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -32009,7 +32099,7 @@ snapshots:
   babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.21.3):
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.3)
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.3)(supports-color@6.1.0)
       core-js-compat: 3.31.0
     transitivePeerDependencies:
       - supports-color
@@ -32017,7 +32107,7 @@ snapshots:
   babel-plugin-polyfill-corejs3@0.8.1(@babel/core@7.21.3):
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-define-polyfill-provider': 0.4.0(@babel/core@7.21.3)
+      '@babel/helper-define-polyfill-provider': 0.4.0(@babel/core@7.21.3)(supports-color@6.1.0)
       core-js-compat: 3.31.0
     transitivePeerDependencies:
       - supports-color
@@ -32025,14 +32115,14 @@ snapshots:
   babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.21.3):
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.3)
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.3)(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-polyfill-regenerator@0.5.0(@babel/core@7.21.3):
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-define-polyfill-provider': 0.4.0(@babel/core@7.21.3)
+      '@babel/helper-define-polyfill-provider': 0.4.0(@babel/core@7.21.3)(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -32079,22 +32169,6 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.3)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.21.3)
 
-  babel-preset-current-node-syntax@1.0.1(@babel/core@7.23.6):
-    dependencies:
-      '@babel/core': 7.23.6
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.6)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.6)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.6)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.6)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.6)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.6)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.6)
-
   babel-preset-current-node-syntax@1.0.1(@babel/core@7.24.7):
     dependencies:
       '@babel/core': 7.24.7
@@ -32117,11 +32191,11 @@ snapshots:
       babel-plugin-jest-hoist: 27.5.1
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.21.3)
 
-  babel-preset-jest@27.5.1(@babel/core@7.23.6):
+  babel-preset-jest@27.5.1(@babel/core@7.24.7):
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.24.7
       babel-plugin-jest-hoist: 27.5.1
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.6)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.7)
 
   babel-preset-jest@29.6.3(@babel/core@7.24.7):
     dependencies:
@@ -32129,7 +32203,7 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.7)
 
-  babel-preset-react-app@10.0.1:
+  babel-preset-react-app@10.0.1(supports-color@6.1.0):
     dependencies:
       '@babel/core': 7.21.3
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.3)
@@ -32141,8 +32215,8 @@ snapshots:
       '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.21.3)
       '@babel/plugin-transform-flow-strip-types': 7.22.5(@babel/core@7.21.3)
       '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.21.3)
-      '@babel/plugin-transform-runtime': 7.21.0(@babel/core@7.21.3)
-      '@babel/preset-env': 7.22.5(@babel/core@7.21.3)
+      '@babel/plugin-transform-runtime': 7.21.0(@babel/core@7.21.3)(supports-color@6.1.0)
+      '@babel/preset-env': 7.22.5(@babel/core@7.21.3)(supports-color@6.1.0)
       '@babel/preset-react': 7.22.5(@babel/core@7.21.3)
       '@babel/preset-typescript': 7.22.5(@babel/core@7.21.3)
       '@babel/runtime': 7.21.0
@@ -32163,7 +32237,7 @@ snapshots:
 
   babel-walk@3.0.0-canary-5:
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.29.7
 
   bail@2.0.2: {}
 
@@ -33090,10 +33164,10 @@ snapshots:
 
   connect-history-api-fallback@2.0.0: {}
 
-  connect@3.7.0:
+  connect@3.7.0(supports-color@6.1.0):
     dependencies:
       debug: 2.6.9(supports-color@6.1.0)
-      finalhandler: 1.1.2
+      finalhandler: 1.1.2(supports-color@6.1.0)
       parseurl: 1.3.3
       utils-merge: 1.0.1
     transitivePeerDependencies:
@@ -33115,8 +33189,8 @@ snapshots:
 
   constantinople@4.0.1:
     dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   constants-browserify@1.0.0: {}
 
@@ -33819,11 +33893,11 @@ snapshots:
   deep-equal@1.1.1:
     dependencies:
       is-arguments: 1.1.1
-      is-date-object: 1.0.5
+      is-date-object: 1.1.0
       is-regex: 1.2.1
       object-is: 1.1.5
       object-keys: 1.1.1
-      regexp.prototype.flags: 1.5.0
+      regexp.prototype.flags: 1.5.4
 
   deep-equal@2.2.2:
     dependencies:
@@ -33993,7 +34067,7 @@ snapshots:
 
   detect-node@2.1.0: {}
 
-  detect-port-alt@1.1.6:
+  detect-port-alt@1.1.6(supports-color@6.1.0):
     dependencies:
       address: 1.2.2
       debug: 2.6.9(supports-color@6.1.0)
@@ -34282,11 +34356,6 @@ snapshots:
       tapable: 2.2.1
 
   enhanced-resolve@5.15.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.2.1
-
-  enhanced-resolve@5.16.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
@@ -34864,67 +34933,67 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-alloy@4.7.0(@babel/eslint-parser@7.23.3(@babel/core@7.21.3)(eslint@8.28.0))(@babel/preset-react@7.22.5(@babel/core@7.21.3))(@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(typescript@4.9.5))(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint-plugin-react@7.32.2(eslint@8.28.0))(eslint@8.28.0)(typescript@4.9.5)(vue-eslint-parser@9.0.3(eslint@8.28.0)):
+  eslint-config-alloy@4.7.0(@babel/eslint-parser@7.23.3(@babel/core@7.24.7)(eslint@8.28.0))(@babel/preset-react@7.22.5(@babel/core@7.24.7))(@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5))(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint-plugin-react@7.32.2(eslint@8.28.0))(eslint@8.28.0)(typescript@4.9.5)(vue-eslint-parser@9.0.3(eslint@8.28.0)):
     dependencies:
       eslint: 8.28.0
     optionalDependencies:
-      '@babel/eslint-parser': 7.23.3(@babel/core@7.21.3)(eslint@8.28.0)
-      '@babel/preset-react': 7.22.5(@babel/core@7.21.3)
-      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(typescript@4.9.5)
+      '@babel/eslint-parser': 7.23.3(@babel/core@7.24.7)(eslint@8.28.0)
+      '@babel/preset-react': 7.22.5(@babel/core@7.24.7)
+      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5)
       '@typescript-eslint/parser': 5.44.0(eslint@8.28.0)(typescript@4.9.5)
       eslint-plugin-react: 7.32.2(eslint@8.28.0)
       typescript: 4.9.5
       vue-eslint-parser: 9.0.3(eslint@8.28.0)
 
-  eslint-config-next@14.2.4(eslint@8.28.0)(typescript@5.4.5):
+  eslint-config-next@14.2.4(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0)(typescript@5.4.5):
     dependencies:
       '@next/eslint-plugin-next': 14.2.4
       '@rushstack/eslint-patch': 1.10.3
-      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0)(typescript@5.4.5)
-      eslint: 8.28.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.1(eslint@8.28.0))(eslint@8.28.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.28.0)
-      eslint-plugin-react: 7.34.3(eslint@8.28.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.28.0)
+      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5)
+      eslint: 8.28.0(supports-color@6.1.0)
+      eslint-import-resolver-node: 0.3.7(supports-color@6.1.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.7(supports-color@6.1.0))(eslint-plugin-import@2.29.1(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0))(eslint@8.28.0(supports-color@6.1.0))
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.28.0(supports-color@6.1.0))
+      eslint-plugin-react: 7.34.3(eslint@8.28.0(supports-color@6.1.0))
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.28.0(supports-color@6.1.0))
     optionalDependencies:
       typescript: 5.4.5
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-config-next@15.1.6(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3):
+  eslint-config-next@15.1.6(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0)(typescript@5.5.3):
     dependencies:
       '@next/eslint-plugin-next': 15.1.6
       '@rushstack/eslint-patch': 1.10.3
-      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)
-      '@typescript-eslint/parser': 5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)
-      eslint: 9.18.0(jiti@2.6.1)
+      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)
+      '@typescript-eslint/parser': 5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.18.0(jiti@2.6.1))
-      eslint-plugin-react: 7.37.4(eslint@9.18.0(jiti@2.6.1))
-      eslint-plugin-react-hooks: 5.1.0(eslint@9.18.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))
+      eslint-plugin-react: 7.37.4(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))
+      eslint-plugin-react-hooks: 5.1.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))
     optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-config-next@16.0.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.0.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.0.1
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.4(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
       globals: 16.4.0
-      typescript-eslint: 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      typescript-eslint: 8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -34936,18 +35005,18 @@ snapshots:
     dependencies:
       eslint: 8.28.0
 
-  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.22.5(@babel/core@7.21.3))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.21.3))(eslint@8.28.0)(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@16.18.12)(typescript@4.9.5))(utf-8-validate@5.0.10))(typescript@4.9.5):
+  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.22.5(@babel/core@7.21.3))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.21.3))(eslint@8.28.0)(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@16.18.12)(typescript@4.9.5))(utf-8-validate@5.0.10))(supports-color@6.1.0)(typescript@4.9.5):
     dependencies:
       '@babel/core': 7.21.3
       '@babel/eslint-parser': 7.22.7(@babel/core@7.21.3)(eslint@8.28.0)
       '@rushstack/eslint-patch': 1.3.2
-      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5)
       '@typescript-eslint/parser': 5.44.0(eslint@8.28.0)(typescript@4.9.5)
-      babel-preset-react-app: 10.0.1
+      babel-preset-react-app: 10.0.1(supports-color@6.1.0)
       confusing-browser-globals: 1.0.11
       eslint: 8.28.0
       eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.22.5(@babel/core@7.21.3))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.21.3))(eslint@8.28.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(supports-color@6.1.0)
       eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@16.18.12)(typescript@4.9.5))(utf-8-validate@5.0.10))(typescript@4.9.5)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.28.0)
       eslint-plugin-react: 7.32.2(eslint@8.28.0)
@@ -34963,7 +35032,7 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-import-resolver-node@0.3.7:
+  eslint-import-resolver-node@0.3.7(supports-color@6.1.0):
     dependencies:
       debug: 3.2.7(supports-color@6.1.0)
       is-core-module: 2.13.1
@@ -34979,13 +35048,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.1(eslint@8.28.0))(eslint@8.28.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.7(supports-color@6.1.0))(eslint-plugin-import@2.29.1(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0))(eslint@8.28.0(supports-color@6.1.0)):
     dependencies:
       debug: 4.3.7(supports-color@6.1.0)
       enhanced-resolve: 5.18.2
-      eslint: 8.28.0
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0)
+      eslint: 8.28.0(supports-color@6.1.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.7(supports-color@6.1.0))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.7(supports-color@6.1.0))(eslint-plugin-import@2.29.1(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0))(eslint@8.28.0(supports-color@6.1.0)))(eslint@8.28.0(supports-color@6.1.0))
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.16.1
@@ -34996,13 +35065,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0):
     dependencies:
       debug: 4.3.7(supports-color@6.1.0)
       enhanced-resolve: 5.18.2
-      eslint: 9.18.0(jiti@2.6.1)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1))
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.16.1
@@ -35013,13 +35082,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 4.3.7(supports-color@6.1.0)
       enhanced-resolve: 5.18.2
       eslint: 9.39.1(jiti@2.6.1)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.16.1
@@ -35040,47 +35109,58 @@ snapshots:
       rimraf: 2.7.1
       webpack: 4.46.0
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.7(supports-color@6.1.0))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.7(supports-color@6.1.0))(eslint-plugin-import@2.29.1(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0))(eslint@8.28.0(supports-color@6.1.0)))(eslint@8.28.0(supports-color@6.1.0)):
     dependencies:
       debug: 3.2.7(supports-color@6.1.0)
     optionalDependencies:
-      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0)(typescript@5.4.5)
-      eslint: 8.28.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.1(eslint@8.28.0))(eslint@8.28.0)
+      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5)
+      eslint: 8.28.0(supports-color@6.1.0)
+      eslint-import-resolver-node: 0.3.7(supports-color@6.1.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.7(supports-color@6.1.0))(eslint-plugin-import@2.29.1(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0))(eslint@8.28.0(supports-color@6.1.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0)):
     dependencies:
       debug: 3.2.7(supports-color@6.1.0)
     optionalDependencies:
-      '@typescript-eslint/parser': 5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)
-      eslint: 9.18.0(jiti@2.6.1)
+      '@typescript-eslint/parser': 5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7(supports-color@6.1.0)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0):
     dependencies:
       debug: 3.2.7(supports-color@6.1.0)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0))(eslint@9.39.1(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.7(supports-color@6.1.0))(eslint-plugin-import@2.29.1(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0))(eslint@8.28.0(supports-color@6.1.0)))(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0):
+    dependencies:
+      debug: 3.2.7(supports-color@6.1.0)
+    optionalDependencies:
+      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5)
+      eslint: 8.28.0(supports-color@6.1.0)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.7(supports-color@6.1.0))(eslint-plugin-import@2.29.1(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0))(eslint@8.28.0(supports-color@6.1.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -35094,17 +35174,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0):
-    dependencies:
-      debug: 3.2.7(supports-color@6.1.0)
-    optionalDependencies:
-      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0)(typescript@5.4.5)
-      eslint: 8.28.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.29.1(eslint@8.28.0))(eslint@8.28.0)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.22.5(@babel/core@7.21.3))(@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.21.3))(eslint@8.28.0):
     dependencies:
       '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.21.3)
@@ -35113,7 +35182,7 @@ snapshots:
       lodash: 4.17.21
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0):
+  eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(supports-color@6.1.0):
     dependencies:
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
@@ -35138,7 +35207,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -35146,9 +35215,9 @@ snapshots:
       array.prototype.flatmap: 1.3.2
       debug: 3.2.7(supports-color@6.1.0)
       doctrine: 2.1.0
-      eslint: 8.28.0
+      eslint: 8.28.0(supports-color@6.1.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.28.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.7(supports-color@6.1.0))(eslint-plugin-import@2.29.1(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0))(eslint@8.28.0(supports-color@6.1.0)))(eslint@8.28.0(supports-color@6.1.0))(supports-color@6.1.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -35159,13 +35228,13 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0)(typescript@5.4.5)
+      '@typescript-eslint/parser': 5.44.0(eslint@8.28.0(supports-color@6.1.0))(typescript@5.4.5)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -35174,9 +35243,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7(supports-color@6.1.0)
       doctrine: 2.1.0
-      eslint: 9.18.0(jiti@2.6.1)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(supports-color@6.1.0))(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -35188,13 +35257,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 5.44.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.5.3)
+      '@typescript-eslint/parser': 5.44.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))(typescript@5.5.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -35205,7 +35274,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -35217,7 +35286,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -35228,24 +35297,24 @@ snapshots:
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.28.0)(typescript@4.9.5)
       eslint: 8.28.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.44.0(@typescript-eslint/parser@5.44.0(eslint@8.28.0)(typescript@4.9.5))(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5)
       jest: 27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@16.18.12)(typescript@4.9.5))(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(typescript@5.8.2):
+  eslint-plugin-jest@27.2.3(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/utils': 5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)
       eslint: 9.39.1(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.2)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.8.2)
       jest: 27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.18.0(jiti@2.6.1)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.8
@@ -35255,7 +35324,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.18.0(jiti@2.6.1)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -35282,6 +35351,26 @@ snapshots:
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
+
+  eslint-plugin-jsx-a11y@6.7.1(eslint@8.28.0(supports-color@6.1.0)):
+    dependencies:
+      '@babel/runtime': 7.21.0
+      aria-query: 5.3.2
+      array-includes: 3.1.6
+      array.prototype.flatmap: 1.3.1
+      ast-types-flow: 0.0.7
+      axe-core: 4.7.2
+      axobject-query: 3.2.1
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 8.28.0(supports-color@6.1.0)
+      has: 1.0.3
+      jsx-ast-utils: 3.3.4
+      language-tags: 1.0.5
+      minimatch: 3.1.2
+      object.entries: 1.1.6
+      object.fromentries: 2.0.6
+      semver: 6.3.1
 
   eslint-plugin-jsx-a11y@6.7.1(eslint@8.28.0):
     dependencies:
@@ -35311,6 +35400,10 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 8.5.0(eslint@8.28.0)
 
+  eslint-plugin-react-hooks@4.6.0(eslint@8.28.0(supports-color@6.1.0)):
+    dependencies:
+      eslint: 8.28.0(supports-color@6.1.0)
+
   eslint-plugin-react-hooks@4.6.0(eslint@8.28.0):
     dependencies:
       eslint: 8.28.0
@@ -35319,9 +35412,9 @@ snapshots:
     dependencies:
       eslint: 9.39.1(jiti@2.6.1)
 
-  eslint-plugin-react-hooks@5.1.0(eslint@9.18.0(jiti@2.6.1)):
+  eslint-plugin-react-hooks@5.1.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0)):
     dependencies:
-      eslint: 9.18.0(jiti@2.6.1)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
 
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
@@ -35373,7 +35466,7 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
 
-  eslint-plugin-react@7.34.3(eslint@8.28.0):
+  eslint-plugin-react@7.34.3(eslint@8.28.0(supports-color@6.1.0)):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
@@ -35382,7 +35475,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.19
-      eslint: 8.28.0
+      eslint: 8.28.0(supports-color@6.1.0)
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.4
       minimatch: 3.1.2
@@ -35395,7 +35488,7 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
 
-  eslint-plugin-react@7.37.4(eslint@9.18.0(jiti@2.6.1)):
+  eslint-plugin-react@7.37.4(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0)):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
@@ -35403,7 +35496,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 9.18.0(jiti@2.6.1)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -35508,14 +35601,19 @@ snapshots:
       eslint: 6.8.0
       eslint-visitor-keys: 2.1.0
 
+  eslint-utils@3.0.0(eslint@8.28.0(supports-color@6.1.0)):
+    dependencies:
+      eslint: 8.28.0(supports-color@6.1.0)
+      eslint-visitor-keys: 2.1.0
+
   eslint-utils@3.0.0(eslint@8.28.0):
     dependencies:
       eslint: 8.28.0
       eslint-visitor-keys: 2.1.0
 
-  eslint-utils@3.0.0(eslint@9.18.0(jiti@2.6.1)):
+  eslint-utils@3.0.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0)):
     dependencies:
-      eslint: 9.18.0(jiti@2.6.1)
+      eslint: 9.18.0(jiti@2.6.1)(supports-color@6.1.0)
       eslint-visitor-keys: 2.1.0
 
   eslint-visitor-keys@1.3.0: {}
@@ -35584,8 +35682,8 @@ snapshots:
 
   eslint@8.28.0:
     dependencies:
-      '@eslint/eslintrc': 1.4.1
-      '@humanwhocodes/config-array': 0.11.10
+      '@eslint/eslintrc': 1.4.1(supports-color@6.1.0)
+      '@humanwhocodes/config-array': 0.11.10(supports-color@6.1.0)
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
@@ -35626,11 +35724,55 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@9.18.0(jiti@2.6.1):
+  eslint@8.28.0(supports-color@6.1.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.18.0(jiti@2.6.1))
+      '@eslint/eslintrc': 1.4.1(supports-color@6.1.0)
+      '@humanwhocodes/config-array': 0.11.10(supports-color@6.1.0)
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      ajv: 6.12.6
+      chalk: 4.1.1
+      cross-spawn: 7.0.3
+      debug: 4.3.4
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.0
+      eslint-utils: 3.0.0(eslint@8.28.0(supports-color@6.1.0))
+      eslint-visitor-keys: 3.4.1
+      espree: 9.6.0
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.20.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-sdsl: 4.4.1
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      regexpp: 3.2.0
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.18.0(jiti@2.6.1)(supports-color@6.1.0))
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.19.1
+      '@eslint/config-array': 0.19.1(supports-color@6.1.0)
       '@eslint/core': 0.10.0
       '@eslint/eslintrc': 3.2.0
       '@eslint/js': 9.18.0
@@ -35680,7 +35822,7 @@ snapshots:
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
       ajv: 6.12.6
       chalk: 4.1.1
       cross-spawn: 7.0.6
@@ -35907,7 +36049,7 @@ snapshots:
 
   exponential-backoff@3.1.1: {}
 
-  express-http-proxy@2.1.1:
+  express-http-proxy@2.1.1(supports-color@6.1.0):
     dependencies:
       debug: 3.2.7(supports-color@6.1.0)
       es6-promise: 4.2.8
@@ -36180,7 +36322,7 @@ snapshots:
 
   filter-obj@1.1.0: {}
 
-  finalhandler@1.1.2:
+  finalhandler@1.1.2(supports-color@6.1.0):
     dependencies:
       debug: 2.6.9(supports-color@6.1.0)
       encodeurl: 1.0.2
@@ -36266,7 +36408,7 @@ snapshots:
 
   flat-cache@3.0.4:
     dependencies:
-      flatted: 3.2.7
+      flatted: 3.3.1
       rimraf: 3.0.2
 
   flat-cache@4.0.1:
@@ -36275,8 +36417,6 @@ snapshots:
       keyv: 4.5.4
 
   flatted@2.0.2: {}
-
-  flatted@3.2.7: {}
 
   flatted@3.3.1: {}
 
@@ -36605,7 +36745,7 @@ snapshots:
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
-      es-object-atoms: 1.0.0
+      es-object-atoms: 1.1.1
 
   get-stream@3.0.0: {}
 
@@ -37316,9 +37456,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@6.1.0):
     dependencies:
-      agent-base: 7.1.1
+      agent-base: 7.1.1(supports-color@6.1.0)
       debug: 4.3.7(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -37345,8 +37485,8 @@ snapshots:
 
   http-proxy-middleware@2.0.6(@types/express@4.17.21):
     dependencies:
-      '@types/http-proxy': 1.17.10
-      http-proxy: 1.18.1(debug@4.3.4)
+      '@types/http-proxy': 1.17.14
+      http-proxy: 1.18.1(debug@4.3.7(supports-color@6.1.0))
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.5
@@ -37355,7 +37495,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy-middleware@3.0.0:
+  http-proxy-middleware@3.0.0(supports-color@6.1.0):
     dependencies:
       '@types/http-proxy': 1.17.14
       debug: 4.3.7(supports-color@6.1.0)
@@ -37401,14 +37541,14 @@ snapshots:
 
   https-proxy-agent@7.0.4:
     dependencies:
-      agent-base: 7.1.1
+      agent-base: 7.1.1(supports-color@6.1.0)
       debug: 4.3.7(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.5:
+  https-proxy-agent@7.0.5(supports-color@6.1.0):
     dependencies:
-      agent-base: 7.1.1
+      agent-base: 7.1.1(supports-color@6.1.0)
       debug: 4.3.7(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -37775,7 +37915,7 @@ snapshots:
 
   is-date-object@1.1.0:
     dependencies:
-      call-bound: 1.0.3
+      call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
   is-decimal@2.0.1: {}
@@ -37966,7 +38106,7 @@ snapshots:
 
   is-regex@1.2.1:
     dependencies:
-      call-bound: 1.0.3
+      call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
@@ -38036,7 +38176,7 @@ snapshots:
 
   is-typed-array@1.1.15:
     dependencies:
-      which-typed-array: 1.1.18
+      which-typed-array: 1.1.19
 
   is-typedarray@1.0.0: {}
 
@@ -38137,12 +38277,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-report@3.0.0:
-    dependencies:
-      istanbul-lib-coverage: 3.2.0
-      make-dir: 3.1.0
-      supports-color: 7.2.0
-
   istanbul-lib-report@3.0.1:
     dependencies:
       istanbul-lib-coverage: 3.2.2
@@ -38152,23 +38286,18 @@ snapshots:
   istanbul-lib-source-maps@4.0.1:
     dependencies:
       debug: 4.3.7(supports-color@6.1.0)
-      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-source-maps@5.0.6:
+  istanbul-lib-source-maps@5.0.6(supports-color@6.1.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       debug: 4.3.7(supports-color@6.1.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
-
-  istanbul-reports@3.1.5:
-    dependencies:
-      html-escaper: 2.0.2
-      istanbul-lib-report: 3.0.0
 
   istanbul-reports@3.1.7:
     dependencies:
@@ -38288,10 +38417,10 @@ snapshots:
 
   jest-config@27.5.1(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@16.18.12)(typescript@4.9.5))(utf-8-validate@5.0.10):
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.24.7
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
-      babel-jest: 27.5.1(@babel/core@7.23.6)
+      babel-jest: 27.5.1(@babel/core@7.24.7)
       chalk: 4.1.1
       ci-info: 3.8.0
       deepmerge: 4.3.1
@@ -38322,10 +38451,10 @@ snapshots:
 
   jest-config@27.5.1(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10):
     dependencies:
-      '@babel/core': 7.23.6
+      '@babel/core': 7.24.7
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
-      babel-jest: 27.5.1(@babel/core@7.23.6)
+      babel-jest: 27.5.1(@babel/core@7.24.7)
       chalk: 4.1.1
       ci-info: 3.8.0
       deepmerge: 4.3.1
@@ -38593,16 +38722,16 @@ snapshots:
 
   jest-snapshot@27.5.1:
     dependencies:
-      '@babel/core': 7.23.6
-      '@babel/generator': 7.23.6
-      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.23.6)
-      '@babel/traverse': 7.23.6
-      '@babel/types': 7.26.0
+      '@babel/core': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.7)
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.29.7
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/babel__traverse': 7.20.1
       '@types/prettier': 2.7.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.6)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.24.7)
       chalk: 4.1.1
       expect: 27.5.1
       graceful-fs: 4.2.11
@@ -38768,7 +38897,7 @@ snapshots:
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.7
+      nwsapi: 2.2.13
       parse5: 6.0.1
       saxes: 5.0.1
       symbol-tree: 3.2.4
@@ -38786,15 +38915,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@6.0.4):
+  jsdom@25.0.1(bufferutil@4.0.8)(supports-color@6.1.0)(utf-8-validate@6.0.4):
     dependencies:
       cssstyle: 4.1.0
       data-urls: 5.0.0
       decimal.js: 10.4.3
       form-data: 4.0.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.5
+      http-proxy-agent: 7.0.2(supports-color@6.1.0)
+      https-proxy-agent: 7.0.5(supports-color@6.1.0)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.13
       parse5: 7.1.2
@@ -38950,7 +39079,7 @@ snapshots:
 
   koa-is-json@1.0.0: {}
 
-  koa-send@5.0.1:
+  koa-send@5.0.1(supports-color@6.1.0):
     dependencies:
       debug: 4.3.7(supports-color@6.1.0)
       http-errors: 1.8.1
@@ -38958,14 +39087,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  koa-static@5.0.0:
+  koa-static@5.0.0(supports-color@6.1.0):
     dependencies:
       debug: 3.2.7(supports-color@6.1.0)
-      koa-send: 5.0.1
+      koa-send: 5.0.1(supports-color@6.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  koa@2.15.3:
+  koa@2.15.3(supports-color@6.1.0):
     dependencies:
       accepts: 1.3.8
       cache-content-type: 1.0.1
@@ -39401,9 +39530,9 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
-      source-map-js: 1.2.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
 
   magicast@0.5.3:
     dependencies:
@@ -39422,7 +39551,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.8.3
 
   make-error@1.3.6: {}
 
@@ -40254,7 +40383,7 @@ snapshots:
   needle@3.3.1:
     dependencies:
       iconv-lite: 0.6.3
-      sax: 1.3.0
+      sax: 1.6.0
     optional: true
 
   negotiator@0.6.3: {}
@@ -40291,7 +40420,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.1.9(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.54.7):
+  next@15.1.9(@babel/core@7.24.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.54.7):
     dependencies:
       '@next/env': 15.1.9
       '@swc/counter': 0.1.3
@@ -40730,14 +40859,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@24.10.0)(bufferutil@4.0.8)(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.4.1)(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)):
+  nuxt@3.12.2(@opentelemetry/api@1.9.0)(@parcel/watcher@2.4.1)(@types/node@24.10.0)(bluebird@3.7.2)(bufferutil@4.0.8)(encoding@0.1.13)(eslint@9.39.1(jiti@2.6.1))(ioredis@5.4.1)(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(supports-color@6.1.0)(terser@5.30.4)(typescript@5.9.3)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.3.6(bufferutil@4.0.8)(rollup@4.16.4)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
+      '@nuxt/devtools': 1.3.6(bluebird@3.7.2)(bufferutil@4.0.8)(rollup@4.16.4)(supports-color@6.1.0)(utf-8-validate@6.0.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4))
       '@nuxt/kit': 3.12.2(magicast@0.3.5)(rollup@4.16.4)
       '@nuxt/schema': 3.12.2(rollup@4.16.4)
       '@nuxt/telemetry': 2.5.4(magicast@0.3.5)(rollup@4.16.4)
-      '@nuxt/vite-builder': 3.12.2(@types/node@24.10.0)(eslint@9.39.1(jiti@2.6.1))(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(typescript@5.9.3)(vue@3.4.30(typescript@5.9.3))
+      '@nuxt/vite-builder': 3.12.2(@types/node@24.10.0)(eslint@9.39.1(jiti@2.6.1))(less@4.2.0)(lightningcss@1.30.2)(magicast@0.3.5)(meow@9.0.0)(optionator@0.9.4)(rollup@4.16.4)(sass-embedded@1.79.4)(sass@1.54.7)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(supports-color@6.1.0)(terser@5.30.4)(typescript@5.9.3)(vue@3.4.30(typescript@5.9.3))
       '@unhead/dom': 1.9.14
       '@unhead/ssr': 1.9.14
       '@unhead/vue': 1.9.14(vue@3.4.30(typescript@5.9.3))
@@ -40837,8 +40966,6 @@ snapshots:
       - xml2js
 
   nwsapi@2.2.13: {}
-
-  nwsapi@2.2.7: {}
 
   nypm@0.3.8:
     dependencies:
@@ -41223,9 +41350,9 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
-  pacote@18.0.6:
+  pacote@18.0.6(bluebird@3.7.2)(supports-color@6.1.0):
     dependencies:
-      '@npmcli/git': 5.0.7
+      '@npmcli/git': 5.0.7(bluebird@3.7.2)
       '@npmcli/installed-package-contents': 2.1.0
       '@npmcli/package-json': 5.2.0
       '@npmcli/promise-spawn': 7.0.2
@@ -41239,7 +41366,7 @@ snapshots:
       npm-registry-fetch: 17.1.0
       proc-log: 4.2.0
       promise-retry: 2.0.1
-      sigstore: 2.3.1
+      sigstore: 2.3.1(supports-color@6.1.0)
       ssri: 10.0.6
       tar: 6.2.1
     transitivePeerDependencies:
@@ -41880,7 +42007,7 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.41)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@20.14.11)(typescript@5.5.3)):
     dependencies:
       lilconfig: 3.1.2
-      yaml: 2.4.5
+      yaml: 2.9.0
     optionalDependencies:
       postcss: 8.4.41
       ts-node: 10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@20.14.11)(typescript@5.5.3)
@@ -41888,7 +42015,7 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.41)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@20.3.3)(typescript@5.4.5)):
     dependencies:
       lilconfig: 3.1.2
-      yaml: 2.4.5
+      yaml: 2.9.0
     optionalDependencies:
       postcss: 8.4.41
       ts-node: 10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@20.3.3)(typescript@5.4.5)
@@ -41896,7 +42023,7 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.5.15)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.5.3)):
     dependencies:
       lilconfig: 3.1.2
-      yaml: 2.4.5
+      yaml: 2.9.0
     optionalDependencies:
       postcss: 8.5.15
       ts-node: 10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.5.3)
@@ -43025,7 +43152,7 @@ snapshots:
 
   rc-field-form@1.27.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.6
       async-validator: 4.2.5
       rc-util: 5.34.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
@@ -43333,14 +43460,14 @@ snapshots:
       - '@types/babel__core'
       - rollup
 
-  react-dev-utils@12.0.1(eslint@8.28.0)(typescript@4.9.5)(vue-template-compiler@2.7.14)(webpack@5.64.4(@swc/core@1.11.13(@swc/helpers@0.5.15))):
+  react-dev-utils@12.0.1(eslint@8.28.0)(supports-color@6.1.0)(typescript@4.9.5)(vue-template-compiler@2.7.14)(webpack@5.64.4(@swc/core@1.11.13(@swc/helpers@0.5.15))):
     dependencies:
       '@babel/code-frame': 7.22.5
       address: 1.2.2
       browserslist: 4.21.5
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      detect-port-alt: 1.1.6
+      detect-port-alt: 1.1.6(supports-color@6.1.0)
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
@@ -43400,6 +43527,16 @@ snapshots:
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 
+  react-helmet-async@1.3.0(react-dom@19.2.1(react@19.2.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.23.6
+      invariant: 2.2.4
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 19.2.1(react@19.2.1)
+      react-fast-compare: 3.2.2
+      shallowequal: 1.1.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -43441,6 +43578,13 @@ snapshots:
       history: 5.3.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.3.0(react@18.3.1)
+
+  react-router-dom@6.3.0(react-dom@19.2.1(react@19.2.1))(react@18.3.1):
+    dependencies:
+      history: 5.3.0
+      react: 18.3.1
+      react-dom: 19.2.1(react@19.2.1)
       react-router: 6.3.0(react@18.3.1)
 
   react-router@6.14.0(react@18.2.0):
@@ -43599,7 +43743,7 @@ snapshots:
 
   redux@4.2.1:
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.6
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -44377,7 +44521,7 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       immutable: 4.3.0
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   sax@1.2.4: {}
 
@@ -44431,9 +44575,9 @@ snapshots:
   schema-utils@4.2.0:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
-      ajv-keywords: 5.1.0(ajv@8.12.0)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   screenfull@5.2.0: {}
 
@@ -44748,21 +44892,21 @@ snapshots:
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
-      object-inspect: 1.13.3
+      object-inspect: 1.13.4
 
   side-channel-map@1.0.1:
     dependencies:
-      call-bound: 1.0.3
+      call-bound: 1.0.4
       es-errors: 1.3.0
-      get-intrinsic: 1.2.7
-      object-inspect: 1.13.3
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
 
   side-channel-weakmap@1.0.2:
     dependencies:
-      call-bound: 1.0.3
+      call-bound: 1.0.4
       es-errors: 1.3.0
-      get-intrinsic: 1.2.7
-      object-inspect: 1.13.3
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
   side-channel@1.0.4:
@@ -44781,7 +44925,7 @@ snapshots:
   side-channel@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      object-inspect: 1.13.3
+      object-inspect: 1.13.4
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
@@ -44792,13 +44936,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sigstore@2.3.1:
+  sigstore@2.3.1(supports-color@6.1.0):
     dependencies:
       '@sigstore/bundle': 2.3.2
       '@sigstore/core': 1.1.0
       '@sigstore/protobuf-specs': 0.3.2
       '@sigstore/sign': 2.3.2
-      '@sigstore/tuf': 2.3.4
+      '@sigstore/tuf': 2.3.4(supports-color@6.1.0)
       '@sigstore/verify': 1.2.1
     transitivePeerDependencies:
       - supports-color
@@ -44813,9 +44957,9 @@ snapshots:
       simple-concat: 1.0.1
     optional: true
 
-  simple-git@3.25.0:
+  simple-git@3.25.0(supports-color@6.1.0):
     dependencies:
-      '@kwsites/file-exists': 1.1.1
+      '@kwsites/file-exists': 1.1.1(supports-color@6.1.0)
       '@kwsites/promise-deferred': 1.1.1
       debug: 4.3.7(supports-color@6.1.0)
     transitivePeerDependencies:
@@ -44912,7 +45056,7 @@ snapshots:
 
   socks-proxy-agent@8.0.3:
     dependencies:
-      agent-base: 7.1.1
+      agent-base: 7.1.1(supports-color@6.1.0)
       debug: 4.3.7(supports-color@6.1.0)
       socks: 2.8.3
     transitivePeerDependencies:
@@ -46163,7 +46307,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 16.18.12
-      acorn: 8.14.0
+      acorn: 8.16.0
       acorn-walk: 8.3.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -46185,7 +46329,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.14.11
-      acorn: 8.14.0
+      acorn: 8.16.0
       acorn-walk: 8.3.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -46207,7 +46351,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.3.3
-      acorn: 8.14.0
+      acorn: 8.16.0
       acorn-walk: 8.3.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -46229,7 +46373,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 24.10.0
-      acorn: 8.14.0
+      acorn: 8.16.0
       acorn-walk: 8.3.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -46251,7 +46395,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 24.10.0
-      acorn: 8.14.0
+      acorn: 8.16.0
       acorn-walk: 8.3.0
       arg: 4.1.3
       create-require: 1.1.1
@@ -46353,7 +46497,7 @@ snapshots:
 
   tty-browserify@0.0.1: {}
 
-  tuf-js@2.2.1:
+  tuf-js@2.2.1(supports-color@6.1.0):
     dependencies:
       '@tufjs/models': 2.0.1
       debug: 4.3.7(supports-color@6.1.0)
@@ -46487,10 +46631,10 @@ snapshots:
     dependencies:
       semver: 7.8.3
 
-  typescript-eslint@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.46.3(@typescript-eslint/parser@8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.3(eslint@9.39.1(jiti@2.6.1))(supports-color@6.1.0)(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.46.3(typescript@5.9.3)
       '@typescript-eslint/utils': 8.46.3(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
@@ -46537,15 +46681,15 @@ snapshots:
 
   ultrahtml@1.6.0: {}
 
-  umi@4.4.12(@babel/core@7.24.7)(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(@types/node@24.10.0)(@types/react@18.3.3)(@types/webpack@4.41.33)(@volar/vue-typescript@1.2.0)(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(lightningcss@1.30.2)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@3.29.4)(sass-embedded@1.79.4)(sass@1.54.7)(sockjs-client@1.6.1)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(type-fest@3.13.1)(typescript@5.8.2)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))):
+  umi@4.4.12(@babel/core@7.24.7)(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(@types/node@24.10.0)(@types/react@18.3.3)(@types/webpack@4.41.33)(@volar/vue-typescript@1.2.0)(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(lightningcss@1.30.2)(prettier@3.8.3)(react-dom@19.2.1(react@19.2.1))(react@18.3.1)(rollup@3.29.4)(sass-embedded@1.79.4)(sass@1.54.7)(sockjs-client@1.6.1)(stylelint@14.16.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(supports-color@6.1.0)(terser@5.30.4)(type-fest@3.13.1)(typescript@5.8.2)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))):
     dependencies:
       '@babel/runtime': 7.23.6
       '@umijs/bundler-utils': 4.4.12
       '@umijs/bundler-webpack': 4.4.12(@types/webpack@4.41.33)(sockjs-client@1.6.1)(type-fest@3.13.1)(typescript@5.8.2)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))
       '@umijs/core': 4.4.12
-      '@umijs/lint': 4.4.12(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(stylelint@14.16.1)(typescript@5.8.2)
-      '@umijs/preset-umi': 4.4.12(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(@types/node@24.10.0)(@types/react@18.3.3)(@types/webpack@4.41.33)(lightningcss@1.30.2)(rollup@3.29.4)(sass-embedded@1.79.4)(sass@1.54.7)(sockjs-client@1.6.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)(type-fest@3.13.1)(typescript@5.8.2)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))
-      '@umijs/renderer-react': 4.4.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@umijs/lint': 4.4.12(eslint@9.39.1(jiti@2.6.1))(jest@27.4.3(bufferutil@4.0.8)(ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@swc/wasm@1.11.13)(@types/node@24.10.0)(typescript@5.8.2))(utf-8-validate@5.0.10))(stylelint@14.16.1)(supports-color@6.1.0)(typescript@5.8.2)
+      '@umijs/preset-umi': 4.4.12(@rspack/core@1.2.8(@rspack/tracing@1.2.8)(@swc/helpers@0.5.15))(@types/node@24.10.0)(@types/react@18.3.3)(@types/webpack@4.41.33)(lightningcss@1.30.2)(rollup@3.29.4)(sass-embedded@1.79.4)(sass@1.54.7)(sockjs-client@1.6.1)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(supports-color@6.1.0)(terser@5.30.4)(type-fest@3.13.1)(typescript@5.8.2)(webpack-dev-server@4.6.0(@types/express@4.17.21)(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15))))(webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)))
+      '@umijs/renderer-react': 4.4.12(react-dom@19.2.1(react@19.2.1))(react@18.3.1)
       '@umijs/server': 4.4.12
       '@umijs/test': 4.4.12(@babel/core@7.24.7)
       '@umijs/utils': 4.4.12
@@ -47187,7 +47331,7 @@ snapshots:
     dependencies:
       vite: 5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)
 
-  vite-node@1.6.0(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4):
+  vite-node@1.6.0(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(supports-color@6.1.0)(terser@5.30.4):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7(supports-color@6.1.0)
@@ -47205,7 +47349,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.4(@types/node@20.14.11)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4):
+  vite-node@2.1.4(@types/node@20.14.11)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(supports-color@6.1.0)(terser@5.30.4):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7(supports-color@6.1.0)
@@ -47247,7 +47391,7 @@ snapshots:
       stylelint: 14.16.1
       typescript: 5.9.3
 
-  vite-plugin-inspect@0.8.4(@nuxt/kit@3.12.2(magicast@0.3.5)(rollup@4.16.4))(rollup@4.16.4)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)):
+  vite-plugin-inspect@0.8.4(@nuxt/kit@3.12.2(magicast@0.3.5)(rollup@4.16.4))(rollup@4.16.4)(supports-color@6.1.0)(vite@5.4.1(@types/node@24.10.0)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.3))(terser@5.30.4)):
     dependencies:
       '@antfu/utils': 0.7.8
       '@rollup/pluginutils': 5.1.0(rollup@4.16.4)
@@ -47265,13 +47409,13 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-mock@2.9.6(mockjs@1.1.0)(rollup@4.61.1)(vite@4.3.9(@types/node@18.14.1)(less@4.2.0)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.4.21))(terser@5.15.0)):
+  vite-plugin-mock@2.9.6(mockjs@1.1.0)(rollup@4.61.1)(supports-color@6.1.0)(vite@4.3.9(@types/node@18.14.1)(less@4.2.0)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.4.21))(terser@5.15.0)):
     dependencies:
       '@rollup/plugin-node-resolve': 13.3.0(rollup@4.61.1)
       '@types/mockjs': 1.0.7
       chalk: 4.1.2
       chokidar: 3.5.3
-      connect: 3.7.0
+      connect: 3.7.0(supports-color@6.1.0)
       debug: 4.3.4
       esbuild: 0.11.3
       fast-glob: 3.2.12
@@ -47608,7 +47752,7 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@2.1.4(@types/node@20.14.11)(jsdom@25.0.1(bufferutil@4.0.8)(utf-8-validate@6.0.4))(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4):
+  vitest@2.1.4(@types/node@20.14.11)(jsdom@25.0.1(bufferutil@4.0.8)(supports-color@6.1.0)(utf-8-validate@6.0.4))(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(supports-color@6.1.0)(terser@5.30.4):
     dependencies:
       '@vitest/expect': 2.1.4
       '@vitest/mocker': 2.1.4(vite@5.4.1(@types/node@20.14.11)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4))
@@ -47628,11 +47772,11 @@ snapshots:
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
       vite: 5.4.1(@types/node@20.14.11)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)
-      vite-node: 2.1.4(@types/node@20.14.11)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(terser@5.30.4)
+      vite-node: 2.1.4(@types/node@20.14.11)(less@4.2.0)(lightningcss@1.30.2)(sass-embedded@1.79.4)(sass@1.54.7)(stylus@0.63.0)(sugarss@4.0.1(postcss@8.5.15))(supports-color@6.1.0)(terser@5.30.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.14.11
-      jsdom: 25.0.1(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      jsdom: 25.0.1(bufferutil@4.0.8)(supports-color@6.1.0)(utf-8-validate@6.0.4)
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -47891,14 +48035,14 @@ snapshots:
 
   vue-eslint-parser@9.0.3(eslint@8.28.0):
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7(supports-color@6.1.0)
       eslint: 8.28.0
       eslint-scope: 7.2.0
-      eslint-visitor-keys: 3.4.1
+      eslint-visitor-keys: 3.4.3
       espree: 9.6.0
       esquery: 1.5.0
       lodash: 4.17.21
-      semver: 7.5.1
+      semver: 7.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -48308,14 +48452,14 @@ snapshots:
     dependencies:
       ansi-html-community: 0.0.8
       bonjour: 3.5.0
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       colorette: 2.0.20
       compression: 1.7.4(supports-color@6.1.0)
       connect-history-api-fallback: 1.6.0
       default-gateway: 6.0.3
       del: 6.1.1
-      express: 4.18.2(supports-color@6.1.0)
-      graceful-fs: 4.2.10
+      express: 4.21.2
+      graceful-fs: 4.2.11
       html-entities: 2.4.0
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)
       ipaddr.js: 2.1.0
@@ -48343,14 +48487,14 @@ snapshots:
     dependencies:
       ansi-html-community: 0.0.8
       bonjour: 3.5.0
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       colorette: 2.0.20
       compression: 1.7.4(supports-color@6.1.0)
       connect-history-api-fallback: 1.6.0
       default-gateway: 6.0.3
       del: 6.1.1
-      express: 4.18.2(supports-color@6.1.0)
-      graceful-fs: 4.2.10
+      express: 4.21.2
+      graceful-fs: 4.2.11
       html-entities: 2.4.0
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)
       ipaddr.js: 2.1.0
@@ -48510,15 +48654,15 @@ snapshots:
   webpack@5.91.0:
     dependencies:
       '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
       '@webassemblyjs/ast': 1.12.1
       '@webassemblyjs/wasm-edit': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
       acorn: 8.16.0
       acorn-import-assertions: 1.9.0(acorn@8.16.0)
-      browserslist: 4.22.2
+      browserslist: 4.23.1
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.16.0
+      enhanced-resolve: 5.18.3
       es-module-lexer: 1.4.1
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -48541,15 +48685,15 @@ snapshots:
   webpack@5.91.0(@swc/core@1.11.13(@swc/helpers@0.5.15)):
     dependencies:
       '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
       '@webassemblyjs/ast': 1.12.1
       '@webassemblyjs/wasm-edit': 1.12.1
       '@webassemblyjs/wasm-parser': 1.12.1
       acorn: 8.16.0
       acorn-import-assertions: 1.9.0(acorn@8.16.0)
-      browserslist: 4.22.2
+      browserslist: 4.23.1
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.16.0
+      enhanced-resolve: 5.18.3
       es-module-lexer: 1.4.1
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -48757,8 +48901,8 @@ snapshots:
 
   with@7.0.2:
     dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       assert-never: 1.2.1
       babel-walk: 3.0.0-canary-5
 
@@ -48781,7 +48925,7 @@ snapshots:
     dependencies:
       '@apideck/better-ajv-errors': 0.2.7(ajv@8.12.0)
       '@babel/core': 7.21.3
-      '@babel/preset-env': 7.22.5(@babel/core@7.21.3)
+      '@babel/preset-env': 7.22.5(@babel/core@7.21.3)(supports-color@6.1.0)
       '@babel/runtime': 7.21.0
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.21.3)(@types/babel__core@7.20.5)(rollup@2.77.3)
       '@rollup/plugin-node-resolve': 11.2.1(rollup@2.77.3)

--- a/test/core/scripts/verify-terminal-runtime.test.ts
+++ b/test/core/scripts/verify-terminal-runtime.test.ts
@@ -183,7 +183,8 @@ describe('verify terminal runtime script', () => {
     expect(result.ok).toBe(true);
     expect(result.skipped).toBe(true);
     expect(result.reason).toBe('node-pty is not installed.');
-    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+    expect(logger.warn.mock.calls[0][0]).toContain('AI terminal mode will be disabled');
   });
 
   it('should use platform-specific helper candidate paths', () => {

--- a/test/core/server/ai-terminal.test.ts
+++ b/test/core/server/ai-terminal.test.ts
@@ -31,9 +31,15 @@ describe('ai terminal helpers', () => {
   });
 
   it('should resolve terminal runtime dependencies from the core package', () => {
-    expect(__TEST_ONLY__.tryRequire('node-pty')?.spawn).toBeTypeOf('function');
-    const ws = __TEST_ONLY__.tryRequire('ws');
+    const nodePty = __TEST_ONLY__.tryRequire('node-pty');
+    // node-pty is optional; when native install is skipped it may be absent
+    if (nodePty) {
+      expect(nodePty.spawn).toBeTypeOf('function');
+    } else {
+      expect(nodePty).toBeNull();
+    }
 
+    const ws = __TEST_ONLY__.tryRequire('ws');
     expect(ws?.WebSocketServer || ws?.Server).toBeTypeOf('function');
   });
 


### PR DESCRIPTION
## Summary

- Move `node-pty` from `dependencies` to `optionalDependencies` in `@code-inspector/core`
- Align package metadata with runtime: AI terminal already loads `node-pty` optionally and disables terminal mode when it is missing
- Clarify docs + postinstall warning when `node-pty` is unavailable

## Why

`node-pty` is a native addon (`prebuild || node-gyp rebuild`). On machines without matching prebuilds / `node-gyp` (e.g. Linux + Bun), installing `code-inspector-plugin@2.x` fails hard:

```text
error: install script from "node-pty" exited with 127
# node-gyp: command not found
```

This blocks **locate** and AI CLI/SDK modes even though they do not need `node-pty`. Terminal mode is the only feature that requires it, and the code already handles absence:

- `ai-terminal.ts`: `loadOptionalModule('node-pty', ...)`
- `verify-terminal-runtime.js`: skips verification when `node-pty` is missing

Related prior fix for install friction: #564 (Windows postinstall hang).

## Test plan

- [ ] Fresh install without build tools / `node-gyp` succeeds (`npm` / `pnpm` / `bun`)
- [ ] Locate mode still works
- [ ] AI CLI/SDK modes still work when configured
- [ ] When `node-pty` installs successfully, terminal mode still works
- [ ] When `node-pty` is skipped, postinstall warns and terminal mode is disabled
- [ ] `vitest` `test/core/scripts/verify-terminal-runtime.test.ts` passes


Made with [Cursor](https://cursor.com)