### PR TITLE
chore(core): clean up bundled dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,11 +51,7 @@
   },
   "dependencies": {
     "@vue/compiler-dom": "^3.5.13",
-    "@xterm/addon-fit": "^0.11.0",
-    "@xterm/addon-web-links": "^0.12.0",
-    "@xterm/xterm": "^6.0.0",
     "chalk": "^4.1.1",
-    "dotenv": "^16.1.4",
     "launch-ide": "1.4.5",
     "portfinder": "^1.0.28",
     "ws": "^8.18.0"
@@ -72,6 +68,9 @@
     "@types/node": "^18.14.1",
     "@vue/babel-plugin-jsx": "^1.1.1",
     "@vue/compiler-sfc": "^3.3.4",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/xterm": "^6.0.0",
     "lit": "^2.6.1",
     "magic-string": "^0.30.0",
     "marked": "^17.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -872,16 +872,16 @@ importers:
         version: 4.33.0(eslint@6.8.0)(typescript@4.1.6)
       '@vue/cli-plugin-babel':
         specifier: ~4.5.8
-        version: 4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(core-js@3.29.0)(vue@3.2.47)
+        version: 4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(core-js@3.29.0)(vue@3.2.47)
       '@vue/cli-plugin-eslint':
         specifier: ~4.5.8
-        version: 4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(eslint@6.8.0)
+        version: 4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(eslint@6.8.0)
       '@vue/cli-plugin-typescript':
         specifier: ~4.5.8
-        version: 4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(@vue/compiler-sfc@3.3.4)(eslint@6.8.0)(typescript@4.1.6)(vue-template-compiler@2.7.14)(vue@3.2.47)
+        version: 4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(@vue/compiler-sfc@3.3.4)(eslint@6.8.0)(typescript@4.1.6)(vue-template-compiler@2.7.14)(vue@3.2.47)
       '@vue/cli-service':
         specifier: ~4.5.8
-        version: 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
+        version: 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
       '@vue/compiler-sfc':
         specifier: ^3.0.0
         version: 3.3.4
@@ -29955,11 +29955,11 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@vue/cli-plugin-babel@4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(core-js@3.29.0)(vue@3.2.47)':
+  '@vue/cli-plugin-babel@4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(core-js@3.29.0)(vue@3.2.47)':
     dependencies:
       '@babel/core': 7.21.3
       '@vue/babel-preset-app': 4.5.19(@babel/core@7.21.3)(core-js@3.29.0)(vue@3.2.47)
-      '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
+      '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
       '@vue/cli-shared-utils': 4.5.19
       babel-loader: 8.3.0(@babel/core@7.21.3)(webpack@4.46.0)
       cache-loader: 4.1.0(webpack@4.46.0)
@@ -29987,9 +29987,9 @@ snapshots:
       - webpack-cli
       - webpack-command
 
-  '@vue/cli-plugin-eslint@4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(eslint@6.8.0)':
+  '@vue/cli-plugin-eslint@4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(eslint@6.8.0)':
     dependencies:
-      '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
+      '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
       '@vue/cli-shared-utils': 4.5.19
       eslint: 6.8.0
       eslint-loader: 2.2.1(eslint@6.8.0)(webpack@4.46.0)
@@ -30007,16 +30007,16 @@ snapshots:
       '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug-plain-loader@1.1.0(pug@3.0.2))(pug@3.0.2)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
       '@vue/cli-shared-utils': 4.5.19
 
-  '@vue/cli-plugin-router@4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))':
+  '@vue/cli-plugin-router@4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))':
     dependencies:
-      '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
+      '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
       '@vue/cli-shared-utils': 4.5.19
 
-  '@vue/cli-plugin-typescript@4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(@vue/compiler-sfc@3.3.4)(eslint@6.8.0)(typescript@4.1.6)(vue-template-compiler@2.7.14)(vue@3.2.47)':
+  '@vue/cli-plugin-typescript@4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))(@vue/compiler-sfc@3.3.4)(eslint@6.8.0)(typescript@4.1.6)(vue-template-compiler@2.7.14)(vue@3.2.47)':
     dependencies:
       '@babel/core': 7.21.3
       '@types/webpack-env': 1.18.1
-      '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
+      '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
       '@vue/cli-shared-utils': 4.5.19
       babel-loader: 8.3.0(@babel/core@7.21.3)(webpack@4.46.0)
       cache-loader: 4.1.0(webpack@4.46.0)
@@ -30043,9 +30043,9 @@ snapshots:
     dependencies:
       '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug-plain-loader@1.1.0(pug@3.0.2))(pug@3.0.2)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
 
-  '@vue/cli-plugin-vuex@4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))':
+  '@vue/cli-plugin-vuex@4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))':
     dependencies:
-      '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
+      '@vue/cli-service': 4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)
 
   '@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug-plain-loader@1.1.0(pug@3.0.2))(pug@3.0.2)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)':
     dependencies:
@@ -30171,7 +30171,7 @@ snapshots:
       - webpack-command
       - whiskers
 
-  '@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)':
+  '@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47)':
     dependencies:
       '@intervolga/optimize-cssnano-plugin': 1.0.6(webpack@4.46.0)
       '@soda/friendly-errors-webpack-plugin': 1.8.1(webpack@4.46.0)
@@ -30180,8 +30180,8 @@ snapshots:
       '@types/webpack': 4.41.33
       '@types/webpack-dev-server': 3.11.6(debug@4.3.4)
       '@vue/cli-overlay': 4.5.19
-      '@vue/cli-plugin-router': 4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))
-      '@vue/cli-plugin-vuex': 4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))
+      '@vue/cli-plugin-router': 4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))
+      '@vue/cli-plugin-vuex': 4.5.19(@vue/cli-service@4.5.19(@vue/compiler-sfc@3.3.4)(bufferutil@4.0.8)(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)(typescript@4.1.6)(utf-8-validate@5.0.10)(vue-template-compiler@2.7.14)(vue@3.2.47))
       '@vue/cli-shared-utils': 4.5.19
       '@vue/component-compiler-utils': 3.3.0(ejs@3.1.10)(lodash@4.17.21)(pug@3.0.2)
       '@vue/preload-webpack-plugin': 1.1.2(html-webpack-plugin@3.2.0(webpack@4.46.0))(webpack@4.46.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1004,21 +1004,9 @@ importers:
       '@vue/compiler-dom':
         specifier: ^3.5.13
         version: 3.5.13
-      '@xterm/addon-fit':
-        specifier: ^0.11.0
-        version: 0.11.0
-      '@xterm/addon-web-links':
-        specifier: ^0.12.0
-        version: 0.12.0
-      '@xterm/xterm':
-        specifier: ^6.0.0
-        version: 6.0.0
       chalk:
         specifier: ^4.1.1
         version: 4.1.2
-      dotenv:
-        specifier: ^16.1.4
-        version: 16.1.4
       launch-ide:
         specifier: 1.4.5
         version: 1.4.5
@@ -1053,6 +1041,15 @@ importers:
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.3.4
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/addon-web-links':
+        specifier: ^0.12.0
+        version: 0.12.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       lit:
         specifier: ^2.6.1
         version: 2.6.1
@@ -10844,10 +10841,6 @@ packages:
   dotenv@10.0.0:
     resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
     engines: {node: '>=10'}
-
-  dotenv@16.1.4:
-    resolution: {integrity: sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==}
-    engines: {node: '>=12'}
 
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
@@ -34182,8 +34175,6 @@ snapshots:
   dotenv-expand@5.1.0: {}
 
   dotenv@10.0.0: {}
-
-  dotenv@16.1.4: {}
 
   dotenv@16.4.5: {}
 


### PR DESCRIPTION
## Summary

- move the bundled `@xterm/*` packages from runtime dependencies to dev dependencies
- remove the unused direct `dotenv` dependency
- update the pnpm lockfile without changing the remaining transitive `dotenv` dependency from `launch-ide`

## Verification

- `pnpm --filter @code-inspector/core build`