### PR TITLE
chore: remove unused internal APIs

### DIFF
--- a/packages/core/src/ai/client/ai-terminal.ts
+++ b/packages/core/src/ai/client/ai-terminal.ts
@@ -787,20 +787,3 @@ export class AITerminalManager {
     }
   }
 }
-
-export async function checkTerminalAvailable(
-  ip: string,
-  port: number,
-  token = '',
-): Promise<boolean> {
-  try {
-    const res = await fetch(
-      `http://${ip}:${port}/ai/terminal/status?token=${encodeURIComponent(token)}`,
-    );
-    if (!res.ok) return false;
-    const data = await res.json();
-    return data.available === true;
-  } catch {
-    return false;
-  }
-}

--- a/packages/core/src/ai/server/runtime-session.ts
+++ b/packages/core/src/ai/server/runtime-session.ts
@@ -168,7 +168,7 @@ export function getRuntimeSession(
   return sessions.get(sessionId) || null;
 }
 
-export function listRuntimeSessions(): RuntimeSessionRecord[] {
+function listRuntimeSessions(): RuntimeSessionRecord[] {
   return Array.from(sessions.values());
 }
 
@@ -334,5 +334,6 @@ export function getRuntimeSessionSnapshot(sessionId: string): {
 
 export const __TEST_ONLY__ = {
   destroyRuntimeSession,
+  listRuntimeSessions,
   scheduleRuntimeCleanup,
 };

--- a/packages/core/src/shared/record-cache.ts
+++ b/packages/core/src/shared/record-cache.ts
@@ -52,7 +52,6 @@ export const updateProjectRecord = (
   const port = patch.port;
   const buildPatch: Partial<RecordInfo> = { ...patch };
   delete buildPatch.port;
-  delete buildPatch.findPort;
 
   if (Object.prototype.hasOwnProperty.call(patch, 'port')) {
     if (port) {

--- a/packages/core/src/shared/type.ts
+++ b/packages/core/src/shared/type.ts
@@ -319,8 +319,6 @@ export type RecordInfo = {
   port: number;
   entry: string;
   output: string; // web component 文件要写入的目录
-  /** @deprecated Server startup is now coordinated with an atomic lock. */
-  findPort?: Promise<number>;
   inputs?: Promise<string[]>; // 入口文件，适配 MPA 项目
   injectTo?: string[]; // 用户自定义的 injectTo 路径
   envDir?: string; // 项目 env 目录

--- a/packages/core/types/ai/client/ai-terminal.d.ts
+++ b/packages/core/types/ai/client/ai-terminal.d.ts
@@ -51,4 +51,3 @@ export declare class AITerminalManager {
     private detachTerminal;
     private injectCSS;
 }
-export declare function checkTerminalAvailable(ip: string, port: number, token?: string): Promise<boolean>;

--- a/packages/core/types/ai/server/runtime-session.d.ts
+++ b/packages/core/types/ai/server/runtime-session.d.ts
@@ -36,7 +36,7 @@ declare function destroyRuntimeSession(sessionId: string): void;
 declare function scheduleRuntimeCleanup(session: RuntimeSessionRecord, delayMs: number): void;
 export declare function createRuntimeSession(kind: RuntimeSessionKind, options?: CreateRuntimeSessionOptions): RuntimeSessionRecord;
 export declare function getRuntimeSession(sessionId: string): RuntimeSessionRecord | null;
-export declare function listRuntimeSessions(): RuntimeSessionRecord[];
+declare function listRuntimeSessions(): RuntimeSessionRecord[];
 export declare function setRuntimeSessionHooks(sessionId: string, hooks: {
     abort?: (() => void) | null;
     cleanup?: (() => void) | null;
@@ -61,6 +61,7 @@ export declare function getRuntimeSessionSnapshot(sessionId: string): {
 } | null;
 export declare const __TEST_ONLY__: {
     destroyRuntimeSession: typeof destroyRuntimeSession;
+    listRuntimeSessions: typeof listRuntimeSessions;
     scheduleRuntimeCleanup: typeof scheduleRuntimeCleanup;
 };
 export {};

--- a/packages/core/types/shared/type.d.ts
+++ b/packages/core/types/shared/type.d.ts
@@ -296,8 +296,6 @@ export type RecordInfo = {
     port: number;
     entry: string;
     output: string;
-    /** @deprecated Server startup is now coordinated with an atomic lock. */
-    findPort?: Promise<number>;
     inputs?: Promise<string[]>;
     injectTo?: string[];
     envDir?: string;

--- a/test/core/server/runtime-session.test.ts
+++ b/test/core/server/runtime-session.test.ts
@@ -7,7 +7,6 @@ import {
   emitRuntimeEvent,
   getRuntimeSession,
   getRuntimeSessionSnapshot,
-  listRuntimeSessions,
   markRuntimeSessionRunning,
   setRuntimeSessionHooks,
   subscribeRuntimeSession,
@@ -106,9 +105,9 @@ describe('runtime session manager', () => {
       lastSeq: 0,
       metadata: { provider: 'codex', model: 'gpt-5-codex' },
     });
-    expect(listRuntimeSessions().some((item) => item.id === session.id)).toBe(
-      true,
-    );
+    expect(
+      __TEST_ONLY__.listRuntimeSessions().some((item) => item.id === session.id),
+    ).toBe(true);
   });
 
   it('should restore detached sessions to running when resubscribed', () => {


### PR DESCRIPTION
## Summary

- remove the unused `checkTerminalAvailable` export
- keep runtime session listing behind the test-only API
- remove the obsolete `findPort` record field and related cleanup
- synchronize generated type declarations and tests

## Verification

- `pnpm exec vitest run test/core/server/runtime-session.test.ts test/core/shared/record-cache --no-coverage`
- `pnpm --filter @code-inspector/core run build`